### PR TITLE
inspect terms that otherwise can't be serialized by exporter

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix/reason.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix/reason.ex
@@ -26,27 +26,27 @@ defmodule OpentelemetryPhoenix.Reason do
 
   def normalize({:badarity, {fun, args}}) do
     {:arity, arity} = Function.info(fun, :arity)
-    [reason: :badarity, function: "#{inspect(fun)}", arity: arity, args: args]
+    [reason: :badarity, function: _inspect(fun), arity: arity, args: _inspect(args)]
   end
 
   def normalize({:badfun, term}) do
-    [reason: :badfun, term: term]
+    [reason: :badfun, term: _inspect(term)]
   end
 
   def normalize({:badstruct, struct, term}) do
-    [reason: :badstruct, struct: struct, term: term]
+    [reason: :badstruct, struct: struct, term: _inspect(term)]
   end
 
   def normalize({:badmatch, term}) do
-    [reason: :badmatch, term: term]
+    [reason: :badmatch, term: _inspect(term)]
   end
 
   def normalize({:badmap, term}) do
-    [reason: :badmap, term: term]
+    [reason: :badmap, term: _inspect(term)]
   end
 
   def normalize({:badbool, op, term}) do
-    [reason: :badbool, operator: op, term: term]
+    [reason: :badbool, operator: op, term: _inspect(term)]
   end
 
   def normalize({:badkey, key}) do
@@ -54,23 +54,23 @@ defmodule OpentelemetryPhoenix.Reason do
   end
 
   def normalize({:badkey, key, map}) do
-    [reason: :badkey, key: key, map: map]
+    [reason: :badkey, key: key, map: _inspect(map)]
   end
 
   def normalize({:case_clause, term}) do
-    [reason: :case_clause, term: term]
+    [reason: :case_clause, term: _inspect(term)]
   end
 
   def normalize({:with_clause, term}) do
-    [reason: :with_clause, term: term]
+    [reason: :with_clause, term: _inspect(term)]
   end
 
   def normalize({:try_clause, term}) do
-    [reason: :try_clause, term: term]
+    [reason: :try_clause, term: _inspect(term)]
   end
 
   def normalize({:badarg, payload}) do
-    [reason: :badarg, payload: payload]
+    [reason: :badarg, payload: _inspect(payload)]
   end
 
   def normalize(other) do
@@ -79,5 +79,13 @@ defmodule OpentelemetryPhoenix.Reason do
 
   def normalize(other, _stacktrace) do
     [reason: other]
+  end
+
+  defp _inspect(term) do
+    if String.Chars.impl_for(term) do
+      term
+    else
+      inspect(term)
+    end
   end
 end

--- a/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
+++ b/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
@@ -140,7 +140,7 @@ defmodule OpentelemetryPhoenixTest do
                             {"exception.message", "Erlang error: :badkey"},
                             {"exception.stacktrace", _stacktrace},
                             {:key, :name},
-                            {:map, %{username: "rick"}}
+                            {:map, "%{username: \"rick\"}"}
                           ]
                         )
                       ],


### PR DESCRIPTION
When you have a case clause error or similar and the argument was a map or tuple for example it won't show up in honeycomb. This data is extremely useful to understand the actual reason of the case clause error.

Do let me know if there is a better place to fix this.