### PR TITLE
Remove exporter race-condition on tests

### DIFF
--- a/instrumentation/opentelemetry_ecto/config/test.exs
+++ b/instrumentation/opentelemetry_ecto/config/test.exs
@@ -11,4 +11,4 @@ config :opentelemetry_ecto, OpentelemetryEcto.TestRepo,
   pool: Ecto.Adapters.SQL.Sandbox
 
 config :opentelemetry,
-  processors: [{:otel_batch_processor, %{scheduled_delay_ms: 1}}]
+  processors: [{:otel_simple_processor, %{}}]

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -15,16 +15,7 @@ defmodule OpentelemetryEctoTest do
   end
 
   setup do
-    :application.stop(:opentelemetry)
-    :application.set_env(:opentelemetry, :tracer, :otel_tracer_default)
-
-    :application.set_env(:opentelemetry, :processors, [
-      {:otel_batch_processor, %{scheduled_delay_ms: 1}}
-    ])
-
-    :application.start(:opentelemetry)
-
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+    :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
 
     OpenTelemetry.Tracer.start_span("test")
 

--- a/instrumentation/opentelemetry_phoenix/config/test.exs
+++ b/instrumentation/opentelemetry_phoenix/config/test.exs
@@ -1,4 +1,4 @@
 import Config
 
 config :opentelemetry,
-  processors: [{:otel_batch_processor, %{scheduled_delay_ms: 1}}]
+  processors: [{:otel_simple_processor, %{}}]

--- a/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
+++ b/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
@@ -17,16 +17,8 @@ defmodule OpentelemetryPhoenixTest do
   end
 
   setup do
-    :application.stop(:opentelemetry)
-    :application.set_env(:opentelemetry, :tracer, :otel_tracer_default)
+    :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
 
-    :application.set_env(:opentelemetry, :processors, [
-      {:otel_batch_processor, %{scheduled_delay_ms: 1}}
-    ])
-
-    :application.start(:opentelemetry)
-
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
     :ok
   end
 


### PR DESCRIPTION
Default exporter immediately attempts on start connect to `:otel-collector` default port. As we don't have any collector running on our test environment, this results in a few warnings. That's not an issue in itself, as code imperially switches to another export, but creates a lot of noise.

This patch moves the exporter setup to `config/test.exs`, essentially removing the need to restart `:opentelemetry` application for each test case. The only work setup blocks do is update the exporter's target pid.

The processor was changed to simple mode, available now, which also remove another vector of (unlikely but theoretically possible) race-conditions.