### PR TITLE
Avoid syntax error for insecure key

### DIFF
--- a/examples/basic_elixir/otel-collector-config.yaml
+++ b/examples/basic_elixir/otel-collector-config.yaml
@@ -14,7 +14,8 @@ exporters:
     endpoint: "http://zipkin:9411/api/v2/spans"
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 extensions:
   zpages: {}
 service:


### PR DESCRIPTION
According to the docs: https://opentelemetry.io/docs/collector/configuration/#exporters the insecure key should be inside tls key otherwise the service doesn't start.