### PR TITLE
Fix compilation warning on otel_telemetry

### DIFF
--- a/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
+++ b/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
@@ -149,7 +149,7 @@ handle_event(_Event,
              _Measurements,
              Metadata,
              #{type := stop, tracer_id := TracerId}) ->
-    Ctx = set_current_telemetry_span(TracerId, Metadata),
+    _Ctx = set_current_telemetry_span(TracerId, Metadata),
     end_telemetry_span(TracerId, Metadata),
     ok;
 handle_event(_Event,


### PR DESCRIPTION
Fix of `Warning: variable 'Ctx' is unused` on compilation logs.