### PR TITLE
Set phoenix attributes on span creation

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -122,8 +122,10 @@ defmodule OpentelemetryPhoenix do
     ]
 
     # start the span with a default name. Route name isn't known until router dispatch
-    OpentelemetryTelemetry.start_telemetry_span(@tracer_id, "HTTP #{conn.method}", meta, %{kind: :server})
-    |> Span.set_attributes(attributes)
+    OpentelemetryTelemetry.start_telemetry_span(@tracer_id, "HTTP #{conn.method}", meta, %{
+      kind: :server,
+      attributes: attributes
+    })
   end
 
   @doc false


### PR DESCRIPTION
By setting the attributes inside `OpentelemetryTelemetry.start_telemetry_span/4` instead of afterwards using `OpenTelemetry.Span.set_attributes/2`, they become available in `:otel_sampler` implementations.