### PR TITLE
Add plug dependency for opentelemetry_phoenix

### DIFF
--- a/instrumentation/opentelemetry_phoenix/mix.exs
+++ b/instrumentation/opentelemetry_phoenix/mix.exs
@@ -61,10 +61,10 @@ defmodule OpentelemetryPhoenix.MixProject do
       {:opentelemetry_api, "~> 1.0.0-rc.4"},
       {:opentelemetry_telemetry, "~> 1.0.0-beta.6"},
       {:telemetry, "~> 0.4 or ~> 1.0.0"},
+      {:plug, ">= 1.11.0"},
       {:cowboy_telemetry, "~> 0.4", only: [:dev, :test]},
       {:opentelemetry, "~> 1.0.0-rc.4", only: [:dev, :test]},
       {:opentelemetry_exporter, "~> 1.0.0-rc.4", only: [:dev, :test]},
-      {:plug, "~> 1.11", only: [:dev, :test]},
       {:ex_doc, "~> 0.26", only: [:dev], runtime: false},
       {:plug_cowboy, "~> 2.4", only: [:dev, :test]},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
I'm currently getting the following compilation warning for opentelemetry_phoenix

    ==> opentelemetry_phoenix
    Compiling 2 files (.ex)
    warning: Plug.Conn.get_peer_data/1 is undefined (module Plug.Conn is not available or is yet to be defined)
      lib/opentelemetry_phoenix.ex:104: OpentelemetryPhoenix.handle_endpoint_start/4

    warning: Plug.Conn.get_req_header/2 is undefined (module Plug.Conn is not available or is yet to be defined)
      lib/opentelemetry_phoenix.ex:211: OpentelemetryPhoenix.header_value/2

Since the opentelemetry_phoenix code is calling functions on `Plug.Conn` directly, the dependency needs to be specified to avoid the compilation warning and ensure the compilation order is correct. 

I also double-checked the plug version requirement and according to the [plug changelog](https://github.com/elixir-plug/plug/blob/v1.6/CHANGELOG.md#v160-2018-06-16) it appears that plug versions as early as 1.6 will work, because that's when `get_peer_data/1` was introduced. However I'd be happy to update the version requirement to a later version if desired.