### PR TITLE
Do not attempt to end a span if ctx wasn't found

### DIFF
--- a/utilities/opentelemetry_telemetry/CHANGELOG.md
+++ b/utilities/opentelemetry_telemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Do not attempt to end a span with if the ctx is undefined.
+
 ## 1.0.0-beta.7
 
 ### Changes

--- a/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
+++ b/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
@@ -56,13 +56,13 @@ set_current_telemetry_span(TracerId, EventMetadata) ->
 
 -spec end_telemetry_span(atom(), telemetry:event_metadata()) -> ok.
 end_telemetry_span(TracerId, EventMetadata) ->
-    {ParentCtx, Ctx} = pop_ctx(TracerId, EventMetadata),
-    case Ctx =/= undefined of
-        true ->
-            otel_span:end_span(Ctx),
+    Ctx = pop_ctx(TracerId, EventMetadata),
+    case Ctx of
+        {ParentCtx, SpanCtx} ->
+            otel_span:end_span(SpanCtx),
             otel_tracer:set_current_span(ParentCtx),
             ok;
-        false ->
+        undefined ->
             ok
     end.
 

--- a/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
+++ b/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
@@ -57,9 +57,14 @@ set_current_telemetry_span(TracerId, EventMetadata) ->
 -spec end_telemetry_span(atom(), telemetry:event_metadata()) -> ok.
 end_telemetry_span(TracerId, EventMetadata) ->
     {ParentCtx, Ctx} = pop_ctx(TracerId, EventMetadata),
-    otel_span:end_span(Ctx),
-    otel_tracer:set_current_span(ParentCtx),
-    ok.
+    case Ctx =/= undefined of
+        true ->
+            otel_span:end_span(Ctx),
+            otel_tracer:set_current_span(ParentCtx),
+            ok;
+        false ->
+            ok
+    end.
 
 -spec store_ctx(ctx_set(), atom(), telemetry:event_metadata()) -> ok.
 store_ctx(SpanCtxSet, TracerId, EventMetadata) ->


### PR DESCRIPTION
If a ctx wasn't found when popping from the pdict, then don't attempt to end the span.