### PR TITLE
avoid crash on websocket upgrade

### DIFF
--- a/instrumentation/opentelemetry_cowboy/src/opentelemetry_cowboy.erl
+++ b/instrumentation/opentelemetry_cowboy/src/opentelemetry_cowboy.erl
@@ -27,6 +27,8 @@ attach_event_handlers() ->
              ],
     telemetry:attach_many(opentelemetry_cowboy_handlers, Events, fun ?MODULE:handle_event/4, #{}).
 
+
+handle_event([cowboy, request, start], _Measurements, #{req := #{headers := #{<<"connection">> := <<"Upgrade">>}}} = _Meta, _Config) -> ok;
 handle_event([cowboy, request, start], _Measurements, #{req := Req} = Meta, _Config) ->
     Headers = maps:get(headers, Req),
     otel_propagator_text_map:extract(maps:to_list(Headers)),
@@ -48,6 +50,7 @@ handle_event([cowboy, request, start], _Measurements, #{req := Req} = Meta, _Con
     SpanName = iolist_to_binary([<<"HTTP ">>, Method]),
     otel_telemetry:start_telemetry_span(?TRACER_ID, SpanName, Meta, #{attributes => Attributes});
 
+handle_event([cowboy, request, stop], _Measurements, #{req := #{headers := #{<<"connection">> := <<"Upgrade">>}}} = _Meta, _Config) -> ok;
 handle_event([cowboy, request, stop], Measurements, Meta, _Config) ->
     Ctx = otel_telemetry:set_current_telemetry_span(?TRACER_ID, Meta),
     Status = maps:get(resp_status, Meta),


### PR DESCRIPTION
On cowboy 2.9:
on a websocket upgrade, the [cowboy, request, stop] event handler crashes because the response is
```erlang
#{pid => <0.692.0>,ref => aade_handler,
                                       req =>
                                           #{body_length => 0,
                                             cert => undefined,
                                             has_body => false,
                                             headers =>
                                                 #{<<"accept-encoding">> =>
                                                       <<"gzip, deflate, br">>,
                                                   <<"accept-language">> =>
                                                       <<"en-GB,en;q=0.9,it;q=0.8,en-US;q=0.7">>,
                                                   <<"cache-control">> =>
                                                       <<"no-cache">>,
                                                   <<"connection">> =>
                                                       <<"Upgrade">>,
                                                   <<"cookie">> =>
                                                       <<"session_id=N8y01WzqfzolrYNGWKJTQD5vSMIF3zOpFVdw10PsfYM=">>,
                                                   <<"host">> =>
                                                       <<"localhost:9295">>,
                                                   <<"origin">> =>
                                                       <<"http://localhost:9295">>,
                                                   <<"pragma">> =>
                                                       <<"no-cache">>,
                                                   <<"sec-websocket-extensions">> =>
                                                       <<"permessage-deflate; client_max_window_bits">>,
                                                   <<"sec-websocket-key">> =>
                                                       <<"Eumcy9TBzTvJ9nbBtXnbmQ==">>,
                                                   <<"sec-websocket-version">> =>
                                                       <<"13">>,
                                                   <<"upgrade">> =>
                                                       <<"websocket">>,
                                                   <<"user-agent">> =>
                                                       <<"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36">>},
                                             host => <<"localhost">>,
                                             method => <<"GET">>,
                                             path => <<"/v1/debug/ws">>,
                                             peer => {{127,0,0,1},50668},
                                             pid => <0.692.0>,port => 9295,
                                             qs => <<>>,ref => aade_handler,
                                             scheme => <<"http">>,
                                             sock => {{127,0,0,1},9295},
                                             streamid => 1,
                                             version => 'HTTP/1.1'}, 
                                       resp_headers => undefined,
                                       resp_status => undefined,streamid => 1} 

Status = maps:get(resp_status, Meta), % resp_status is undefined!!

```
resp status is undefined, but since the operation is successful the `error` key is missing in the map.
```erlang
{ErrorType, Error, Reason} = maps:get(error, Meta), % call is successul, error key not present
```
and this crashes the module.
To avoid the issue, my proposal is to ignore spans originated from a websocket upgrade call.
 