### PR TITLE
Report Redix error messages through OTel status

### DIFF
--- a/instrumentation/opentelemetry_redix/CHANGELOG.md
+++ b/instrumentation/opentelemetry_redix/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1
+
+### Bug fixes
+
+* Report errors via OpenTelemetry SetStatus API instead of custom
+  attributes
+
 ## 0.1.0
 
 * Initial release

--- a/instrumentation/opentelemetry_redix/mix.exs
+++ b/instrumentation/opentelemetry_redix/mix.exs
@@ -5,7 +5,7 @@ defmodule OpentelemetryRedix.MixProject do
     [
       app: :opentelemetry_redix,
       description: description(),
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -23,7 +23,7 @@ defmodule OpentelemetryRedix.MixProject do
   defp package do
     [
       files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*),
-      licenses: ["Apache-2"],
+      licenses: ["Apache-2.0"],
       links: %{
         "GitHub" =>
           "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix",


### PR DESCRIPTION
Instead of custom attributes, leverage the status description as described in Semantic Conventions. This approach is taken from current `opentelemetry_ecto` implementation.

Small non-related change is a fix the license description in `mix.exs`.