### PR TITLE
Fix two use cases of Ecto span propagation

### DIFF
--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -192,6 +192,29 @@ defmodule OpentelemetryEctoTest do
     assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:comments")}
   end
 
+  test "nested query within Task does not skip parent span" do
+    user = Repo.insert!(%User{email: "opentelemetry@erlang.org"})
+    Repo.insert!(%Post{body: "We got traced!", user: user})
+    Repo.insert!(%Comment{body: "We got traced!", user: user})
+
+    attach_handler()
+
+    Tracer.with_span "root span" do
+      task =
+        Task.async(fn ->
+          Tracer.with_span "parent span" do
+            Repo.all(User)
+          end
+        end)
+
+      Task.await(task)
+    end
+
+    assert_receive {:span, span(span_id: _root_span_id, name: "root span")}
+    assert_receive {:span, span(span_id: parent_span_id, name: "parent span")}
+    assert_receive {:span, span(parent_span_id: ^parent_span_id, name: "opentelemetry_ecto.test_repo.query:users")}
+  end
+
   def attach_handler(config \\ []) do
     # For now setup the handler manually in each test
     handler = {__MODULE__, self()}

--- a/instrumentation/opentelemetry_ecto/test/test_helper.exs
+++ b/instrumentation/opentelemetry_ecto/test/test_helper.exs
@@ -1,5 +1,5 @@
 OpentelemetryEcto.TestRepo.start_link()
 
-ExUnit.start()
+ExUnit.start(capture_log: true)
 
 Ecto.Adapters.SQL.Sandbox.mode(OpentelemetryEcto.TestRepo, {:shared, self()})


### PR DESCRIPTION
First one is related to `OpenTelemetry.Ctx` API.

I've noticed in a few scenarios the current span of a trace may get lost after Ecto calls. Looking at the The `attach/1` typespec, it's a Ctx -> Token, while `dettach/1` as Token -> Ctx function. That made me assume the expected input of dettach is the return type of attach. Indeed, after this change we got the behavior of Ecto calls preserve the parent span untouched.

That leads to a second bug found. When ecto does simple calls within a Task, due the special propagation code for preloads that means it will skip the current span, if any.  The solution here is to first check the current process.

One test was added to reproduce this bug.