### PR TITLE
adds missing comma to opentelemetery_exporter config example

### DIFF
--- a/examples/basic_phoenix_ecto/config/runtime.exs
+++ b/examples/basic_phoenix_ecto/config/runtime.exs
@@ -86,7 +86,7 @@ if config_env() == :prod do
 
     # Example configuration for Lightstep.com, for more refers to:
     # https://github.com/open-telemetry/opentelemetry-erlang/tree/main/apps/opentelemetry_exporter#application-environment
-    # config :opentelemetry_exporter
+    # config :opentelemetry_exporter,
     #   # You can also configure the compression type for exporting traces.
     #   oltp_traces_compression: :gzip,
     #   otlp_traces_endpoint: "https://ingest.lightstep.com:443/traces/otlp/v0.9",


### PR DESCRIPTION
I didn't feel this was worthy of opening a bug ticket as it's just a missing comma in some documentation. If you would like me to open a ticket and link this PR to it I will.

### Issue:

Uncommenting the lightstep example configuration results in the following error: 


### Before Change: 

```
** (SyntaxError) config/runtime.exs:95:9: unexpectedly reached end of line. The current expression is invalid or incomplete
    (elixir 1.13.4) lib/code.ex:403: Code.validated_eval_string/3
    (elixir 1.13.4) lib/config.ex:260: Config.__eval__!/3
    (elixir 1.13.4) lib/config/reader.ex:92: Config.Reader.read!/2
    (mix 1.13.4) lib/mix/tasks/loadconfig.ex:62: Mix.Tasks.Loadconfig.load_runtime/1
    (mix 1.13.4) lib/mix/tasks/app.config.ex:39: Mix.Tasks.App.Config.run/1
    (mix 1.13.4) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.13.4) lib/mix/tasks/app.start.ex:46: Mix.Tasks.App.Start.run/1
```


### After Change: 

Starts as expected