### PR TITLE
opentelemetry_ecto  - add possibility to setup additional attributes.

### DIFF
--- a/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
+++ b/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
@@ -36,7 +36,7 @@ defmodule OpentelemetryEcto do
       defaults to the concatenation of the event name with periods, e.g.
       `"blog.repo.query"`. This will always be followed with a colon and the
       source (the table name for SQL adapters).
-    * `:attributes` - additional attributes to include in the span. If there
+    * `:additional_attributes` - additional attributes to include in the span. If there
       are conflits with default provided attributes, the ones provided with
       this config will have precedence.
   """
@@ -77,7 +77,7 @@ defmodule OpentelemetryEcto do
       end <> if source != nil, do: ":#{source}", else: ""
 
     time_unit = Keyword.get(config, :time_unit, :microsecond)
-    config_attributes = Keyword.get(config, :attributes, %{})
+    additional_attributes = Keyword.get(config, :additional_attributes, %{})
 
     db_type =
       case type do
@@ -106,7 +106,7 @@ defmodule OpentelemetryEcto do
           acc
       end)
       |> Map.merge(base_attributes)
-      |> Map.merge(config_attributes)
+      |> Map.merge(additional_attributes)
 
     parent_context = OpentelemetryProcessPropagator.fetch_parent_ctx(1, :"$callers")
 

--- a/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
+++ b/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
@@ -36,6 +36,9 @@ defmodule OpentelemetryEcto do
       defaults to the concatenation of the event name with periods, e.g.
       `"blog.repo.query"`. This will always be followed with a colon and the
       source (the table name for SQL adapters).
+    * `:attributes` - additional attributes to include in the span. If there
+      are conflits with default provided attributes, the ones provided with
+      this config will have precedence.
   """
   def setup(event_prefix, config \\ []) do
     event = event_prefix ++ [:query]
@@ -74,6 +77,7 @@ defmodule OpentelemetryEcto do
       end <> if source != nil, do: ":#{source}", else: ""
 
     time_unit = Keyword.get(config, :time_unit, :microsecond)
+    config_attributes = Keyword.get(config, :attributes, %{})
 
     db_type =
       case type do
@@ -101,6 +105,8 @@ defmodule OpentelemetryEcto do
         _, acc ->
           acc
       end)
+      |> Map.merge(base_attributes)
+      |> Map.merge(config_attributes)
 
     parent_context = OpentelemetryProcessPropagator.fetch_parent_ctx(1, :"$callers")
 
@@ -111,7 +117,7 @@ defmodule OpentelemetryEcto do
     s =
       OpenTelemetry.Tracer.start_span(span_name, %{
         start_time: start_time,
-        attributes: Map.merge(attributes, base_attributes),
+        attributes: attributes,
         kind: :client
       })
 

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -61,6 +61,19 @@ defmodule OpentelemetryEctoTest do
            } = :otel_attributes.map(attributes)
   end
 
+  test "include config attributes" do
+    attach_handler(
+      attributes: %{"config.attribute": "special value", "db.instance": "my_instance_config"}
+    )
+
+    Repo.all(User)
+
+    assert_receive {:span, span(attributes: attributes)}
+
+    assert %{"config.attribute": "special value", "db.instance": "my_instance_config"} =
+             :otel_attributes.map(attributes)
+  end
+
   test "changes the time unit" do
     attach_handler(time_unit: :millisecond)
 
@@ -111,7 +124,7 @@ defmodule OpentelemetryEctoTest do
     attach_handler()
 
     try do
-      Repo.all(from u in "users", select: u.non_existant_field)
+      Repo.all(from(u in "users", select: u.non_existant_field))
     rescue
       _ -> :ok
     end
@@ -137,9 +150,24 @@ defmodule OpentelemetryEctoTest do
     end
 
     assert_receive {:span, span(span_id: root_span_id, name: "parent span")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:users")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:posts")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:comments")}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:users"
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:posts"
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:comments"
+                    )}
   end
 
   test "preloads in parallel are tied to the parent span" do
@@ -154,9 +182,24 @@ defmodule OpentelemetryEctoTest do
     end
 
     assert_receive {:span, span(span_id: root_span_id, name: "parent span")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:users")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:posts")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:comments")}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:users"
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:posts"
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:comments"
+                    )}
   end
 
   test "nested query preloads are tied to the parent span" do
@@ -167,21 +210,45 @@ defmodule OpentelemetryEctoTest do
     attach_handler()
 
     Tracer.with_span "parent span" do
-      users_query = from u in User, preload: [:posts, :comments]
-      comments_query = from c in Comment, preload: [user: ^users_query]
+      users_query = from(u in User, preload: [:posts, :comments])
+      comments_query = from(c in Comment, preload: [user: ^users_query])
       Repo.all(Query.from(User, preload: [:posts, comments: ^comments_query]))
     end
 
     assert_receive {:span, span(span_id: root_span_id, name: "parent span")}
     # root query
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:users")}
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:users"
+                    )}
+
     # comments preload
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:comments")}
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:comments"
+                    )}
+
     # users preload
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:users")}
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:users"
+                    )}
+
     # preloads of user
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:posts")}
-    assert_receive {:span, span(parent_span_id: ^root_span_id, name: "opentelemetry_ecto.test_repo.query:comments")}
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:posts"
+                    )}
+
+    assert_receive {:span,
+                    span(
+                      parent_span_id: ^root_span_id,
+                      name: "opentelemetry_ecto.test_repo.query:comments"
+                    )}
   end
 
   def attach_handler(config \\ []) do


### PR DESCRIPTION
current implementation of opentelemetry_ecto doesn't allow to setup additional attributes to the span. this PR add this possibility by allowing an `:attributes` option on setup.