### PR TITLE
Bump opentelemetry_tesla version

### DIFF
--- a/instrumentation/opentelemetry_tesla/README.md
+++ b/instrumentation/opentelemetry_tesla/README.md
@@ -11,7 +11,7 @@ by adding `opentelemetry_tesla` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:opentelemetry_tesla, "~> 2.0.1"}
+    {:opentelemetry_tesla, "~> 2.1.0"}
   ]
 end
 ```

--- a/instrumentation/opentelemetry_tesla/mix.exs
+++ b/instrumentation/opentelemetry_tesla/mix.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryTesla.MixProject do
   def project do
     [
       app: :opentelemetry_tesla,
-      version: "2.0.1",
+      version: "2.1.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -33,7 +33,8 @@ defmodule OpentelemetryTesla.MixProject do
         "GitHub" =>
           "https://github.com/open-telemetry/opentelemetry-erlang-contrib/instrumentation/opentelemetry_tesla",
         "OpenTelemetry Erlang" => "https://github.com/open-telemetry/opentelemetry-erlang",
-        "OpenTelemetry Erlang Contrib" => "https://github.com/open-telemetry/opentelemetry-erlang-contrib",
+        "OpenTelemetry Erlang Contrib" =>
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib",
         "OpenTelemetry.io" => "https://opentelemetry.io"
       }
     ]


### PR DESCRIPTION
Bump version from `2.0.1` to `2.10` as there were some minor changes in the past few weeks.

- https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/106/
- https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/105