### PR TITLE
Fix ctx return types for process_propagator functions

### DIFF
--- a/propagators/opentelemetry_process_propagator/lib/opentelemetry_process_propagator.ex
+++ b/propagators/opentelemetry_process_propagator/lib/opentelemetry_process_propagator.ex
@@ -84,7 +84,7 @@ defmodule OpentelemetryProcessPropagator do
   @doc """
   Attempt to fetch an otel context from a give pid.
   """
-  @spec fetch_ctx(pid) :: OpenTelemetry.span_ctx() | :undefined
+  @spec fetch_ctx(pid) :: OpenTelemetry.Ctx.t() | :undefined
   defdelegate fetch_ctx(pid), to: :opentelemetry_process_propagator
 
   @doc """
@@ -92,14 +92,14 @@ defmodule OpentelemetryProcessPropagator do
 
   This is equivalent to calling `fetch_parent_ctx(1, :"$ancestors")`
   """
-  @spec fetch_parent_ctx() :: OpenTelemetry.span_ctx() | :undefined
+  @spec fetch_parent_ctx() :: OpenTelemetry.Ctx.t() | :undefined
   defdelegate fetch_parent_ctx(), to: :opentelemetry_process_propagator
 
   @doc """
   Attempt to find an otel context in a spawning process within `n` number of parent
   processes
   """
-  @spec fetch_parent_ctx(non_neg_integer()) :: OpenTelemetry.span_ctx() | :undefined
+  @spec fetch_parent_ctx(non_neg_integer()) :: OpenTelemetry.Ctx.t() | :undefined
   defdelegate fetch_parent_ctx(depth), to: :opentelemetry_process_propagator
 
   @doc """
@@ -110,6 +110,6 @@ defmodule OpentelemetryProcessPropagator do
   Processes spawned by `proc_lib` are stored under `:"$ancestors`. The
   Elixir `Task` module uses the `:"$callers` key.
   """
-  @spec fetch_parent_ctx(non_neg_integer(), atom()) :: OpenTelemetry.span_ctx() | :undefined
+  @spec fetch_parent_ctx(non_neg_integer(), atom()) :: OpenTelemetry.Ctx.t() | :undefined
   defdelegate fetch_parent_ctx(max_depth, key), to: :opentelemetry_process_propagator
 end

--- a/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
+++ b/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
@@ -5,15 +5,15 @@
          fetch_parent_ctx/1,
          fetch_parent_ctx/2]).
 
--spec fetch_parent_ctx() -> opentelemetry:span_ctx() | undefined.
+-spec fetch_parent_ctx() -> otel_ctx:t() | undefined.
 fetch_parent_ctx() ->
     fetch_parent_ctx(1, '$ancestors').
 
--spec fetch_parent_ctx(non_neg_integer()) -> opentelemetry:span_ctx() | undefined.
+-spec fetch_parent_ctx(non_neg_integer()) -> otel_ctx:t() | undefined.
 fetch_parent_ctx(MaxDepth) ->
     fetch_parent_ctx(MaxDepth, '$ancestors').
 
--spec fetch_parent_ctx(non_neg_integer(), atom()) -> opentelemetry:span_ctx() | undefined.
+-spec fetch_parent_ctx(non_neg_integer(), atom()) -> otel_ctx:t() | undefined.
 fetch_parent_ctx(MaxDepth, Key) ->
     Pids = pids(Key, pdict(self())),
     inspect_parent(undefined, lists:sublist(Pids, MaxDepth)).
@@ -30,7 +30,7 @@ inspect_parent(_Ctx, [Pid | Rest]) ->
             inspect_parent(OtelCtx, [])
     end.
 
--spec fetch_ctx(pid()) -> opentelemetry:span_ctx() | undefined.
+-spec fetch_ctx(pid()) -> otel_ctx:t() | undefined.
 fetch_ctx(Pid) ->
     case pdict(Pid) of
         undefined ->
@@ -48,7 +48,7 @@ pdict(Pid) ->
             undefined
     end.
 
--spec otel_ctx([{term(), term()}]) -> opentelemetry:span_ctx() | undefined.
+-spec otel_ctx([{term(), term()}]) -> otel_ctx:t() | undefined.
 otel_ctx(Dictionary) ->
     case lists:keyfind('$__current_otel_ctx', 1, Dictionary) of
         false ->


### PR DESCRIPTION
I was getting dialyzer warnings when running the following code (copied from opentelemetry_ecto)

```elixir
    parent_context = OpentelemetryProcessPropagator.fetch_parent_ctx(1, :"$callers")

    unless parent_context == :undefined do
      OpenTelemetry.Ctx.attach(parent_context)
    end
```

Dialyzer warning
```
The function call will not succeed.

OpenTelemetry.Ctx.attach(
  _parent_context ::
    :undefined
    | {:span_ctx, non_neg_integer(), non_neg_integer(), :undefined | integer(),
       [
         {binary()
          | maybe_improper_list(
              binary() | maybe_improper_list(any(), binary() | []) | byte(),
              binary() | []
            ),
          binary()
          | maybe_improper_list(
              binary() | maybe_improper_list(any(), binary() | []) | byte(),
              binary() | []
            )}
       ], false | true | :undefined, boolean(), false | true | :undefined,
       :undefined | {atom(), _}}
)

will never return since the 1st arguments differ
from the success typing arguments:

(map())
```

After inspecting the return types, this warning did seem to be accurate and when I put an `IO.inspect/1` after `OpentelemetryProcessPropagator.fetch_parent_ctx(1, :"$callers")` and saw the following is actually being returned.

```elixir
%{
  {:otel_tracer, :span_ctx} => {:span_ctx,
   120546514915874756856876375438658633729, 8170696101348861860, 1, [], true,
   false, true,
   {:otel_span_ets, #Function<2.11792691/1 in :otel_tracer_server.on_end/1>}}
}
```

This behavior along with this comment https://github.com/open-telemetry/opentelemetry-erlang/issues/443#issuecomment-1229251846 makes me think the correct type should be `otel_ctx:t/0`