### PR TITLE
publish latest updates

### DIFF
--- a/instrumentation/opentelemetry_ecto/CHANGELOG.md
+++ b/instrumentation/opentelemetry_ecto/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.0
+
+### Changed
+
+* Allow setting additional attributes
+
+### Fixes
+
+* Fix span linking in additional task-spawned use cases
+
 ## 1.0.0
 
 ### Changed

--- a/instrumentation/opentelemetry_ecto/mix.exs
+++ b/instrumentation/opentelemetry_ecto/mix.exs
@@ -5,7 +5,7 @@ defmodule OpentelemetryEcto.MixProject do
     [
       app: :opentelemetry_ecto,
       description: description(),
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/instrumentation/opentelemetry_oban/CHANGELOG.md
+++ b/instrumentation/opentelemetry_oban/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0
+
+### Changed
+
+* Publish 1.0
+
+### Fixes
+
+* Fix issue with insert_all
+
 ## 0.2.0-rc.5
 
 ### Changed

--- a/instrumentation/opentelemetry_oban/mix.exs
+++ b/instrumentation/opentelemetry_oban/mix.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryOban.MixProject do
   def project do
     [
       app: :opentelemetry_oban,
-      version: "0.2.0-rc.6",
+      version: "1.0.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/propagators/opentelemetry_process_propagator/CHANGELOG.md
+++ b/propagators/opentelemetry_process_propagator/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.1
+  
+### Fixes
+  
+- Fix return spec types
+
 ## v0.2.0
   
 ### Added

--- a/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.app.src
+++ b/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_process_propagator,
  [{description, "Tools for OpenTelemetry context propagation across process boundaries"},
-  {vsn, "0.2.0"},
+  {vsn, "0.2.1"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
Publish updates for tesla (version was already bumped), ecto, oban, and process propagator.

Oban has been set to 1.0 to end the 0.2rc lines.