### PR TITLE
Adding compose file only with dependencies in example

### DIFF
--- a/examples/basic_phoenix_ecto/README.md
+++ b/examples/basic_phoenix_ecto/README.md
@@ -36,6 +36,32 @@ Assuming you already have Docker and Docker Compose installed:
    look at the sample trace.
 6. Run `docker-compose down` to destroy the created resources.
 
+# Adding traces into your Elixir project
+
+1. Add otel dependencies into your project's `mix.exs` file
+```
+  defp deps do
+    [...
+      {:opentelemetry_phoenix, "~> 1.0.0-rc.7"},
+      {:opentelemetry_ecto, "~> 1.1.0"},
+      {:opentelemetry_exporter, "~> 1.2.1"}
+    ]
+  end
+```
+2. Run `mix deps.get` in order to get the otel dependencies into your project
+3. Add the `docker-compose-dependencies.yaml` in yout project folder
+4. Add the following snippet to your project's `dev.exs` file
+```
+  config :opentelemetry, :processors,
+    otel_batch_processor: %{
+      exporter: {:opentelemetry_exporter, %{endpoints: ["http://localhost:4318"]}}
+    }
+```
+5. run `docker-compose -f docker-compose-dependencies.yaml up -d`
+6. run `iex -S mix` or `iex -S mix phx.server` for a phoenix project
+7. Check the `Getting Started` session steps `4` and `5` to check the traces
+
+
 ## Different ways to export traces
 
 In general, there are 2 ways you can export your OpenTelemetry traces.

--- a/examples/basic_phoenix_ecto/docker-compose-dependencies.yaml
+++ b/examples/basic_phoenix_ecto/docker-compose-dependencies.yaml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  postgres:
+    image: 'postgres:latest'
+    ports:
+      - 5432:5432
+
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: demo_dev
+
+  otel:
+    image: otel/opentelemetry-collector-contrib-dev:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    ports:
+      - '4318:4318'
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+
+  zipkin:
+    image: openzipkin/zipkin-slim
+    ports:
+      - '9411:9411'
+
+  # Jaeger
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268"
+      - "14250"


### PR DESCRIPTION
This PR adds a compose file with only the needed dependencies to see the traces of your Elixir project and some documentation around it.