### PR TITLE
[opentelemetry-tesla] Add an option to not inject_distributed_tracing_headers

### DIFF
--- a/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -423,5 +423,24 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
     assert is_binary(traceparent)
   end
 
+  test "Do not injects distributed tracing headers if specified in options" do
+    OpentelemetryTelemetry.start_telemetry_span(
+      "tracer_id",
+      "my_label",
+      %{},
+      %{kind: :client}
+    )
+
+    assert {:ok,
+            %Tesla.Env{
+              headers: []
+            }} =
+             Tesla.Middleware.OpenTelemetry.call(
+               %Tesla.Env{url: ""},
+               [],
+               inject_distributed_tracing_headers: false
+             )
+  end
+
   defp endpoint_url(port), do: "http://localhost:#{port}/"
 end


### PR DESCRIPTION
Hey team thanks for this wonderful library ! :) 

I added an option inject_distributed_tracing_headers which is set as true by default.

When it's set to false the middleware won't add distributed tracing headers to the request.

This can be useful when you are sending HTTP request to an endpoint you don't own.