### PR TITLE
Add `opentelemetry_telemetry` to application dependencies

### DIFF
--- a/instrumentation/opentelemetry_cowboy/src/opentelemetry_cowboy.app.src
+++ b/instrumentation/opentelemetry_cowboy/src/opentelemetry_cowboy.app.src
@@ -6,6 +6,7 @@
    [kernel,
     stdlib,
     opentelemetry_api,
+    opentelemetry_telemetry,
     telemetry,
     telemetry_registry
    ]},


### PR DESCRIPTION
Without it the event handler throws the undefined function error, because `opentelemetry_telemetry` is not included in the release.