### PR TITLE
Tesla.Middleware.OpenTelemetry: handle 400 as error

### DIFF
--- a/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -59,7 +59,7 @@ defmodule Tesla.Middleware.OpenTelemetry do
     result
   end
 
-  defp handle_result({:ok, %Tesla.Env{status: status} = env}) when status > 400 do
+  defp handle_result({:ok, %Tesla.Env{status: status} = env}) when status >= 400 do
     OpenTelemetry.Tracer.set_status(OpenTelemetry.status(:error, ""))
 
     {:ok, env}


### PR DESCRIPTION
The 400 (bad request) was not being handled as an error. I took the liberty to repeat the tests for the most common HTTP error codes.