### PR TITLE
[grpcbox] bump version

### DIFF
--- a/instrumentation/opentelemetry_grpcbox/src/opentelemetry_grpcbox.app.src
+++ b/instrumentation/opentelemetry_grpcbox/src/opentelemetry_grpcbox.app.src
@@ -1,6 +1,6 @@
 {application, opentelemetry_grpcbox,
  [{description, "grpcbox interceptor for OpenTelemetry instrumentation"},
-  {vsn, "0.1.0"},
+  {vsn, "0.2.0"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
bump release version of grpcbox to include recent, merged changes.

I apologize: how does opentelemetry_grpcbox actually get published to hex (https://hex.pm/packages/opentelemetry_grpcbox)? if we bump the version here, will a github action here (or in opentelemetry-erlang) build and publish it to hex?