### PR TITLE
Allow start_link/1 to be delegated

### DIFF
--- a/propagators/opentelemetry_process_propagator/lib/task/supervisor.ex
+++ b/propagators/opentelemetry_process_propagator/lib/task/supervisor.ex
@@ -831,6 +831,6 @@ defmodule OpentelemetryProcessPropagator.Task.Supervisor do
   end
 
   defdelegate children(supervisor), to: Task.Supervisor
-  defdelegate start_link(), to: Task.Supervisor
+  defdelegate start_link(options \\ []), to: Task.Supervisor
   defdelegate terminate_child(supervisor, pid), to: Task.Supervisor
 end


### PR DESCRIPTION
## Context

This PR fixes the `UndefinedFunctionError` when calling `start_link/1`

@bryannaegele 