### PR TITLE
Improve Req with OTel http spec

### DIFF
--- a/instrumentation/opentelemetry_req/CHANGELOG.md
+++ b/instrumentation/opentelemetry_req/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Use span_name if provided, otherwise use path_params. If there are no
+  path_params, default to request path
+
 ## 0.1.2
 
 ### Fixes

--- a/instrumentation/opentelemetry_req/CHANGELOG.md
+++ b/instrumentation/opentelemetry_req/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 * Change span_name to follow [OpenTelemetry http spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#name)
-* Use span_name if provided, otherwise use path_params. If there are no
-  path_params, default to request path
+* Use span_name if provided, otherwise use path_params. If there are no path_params,
+  default to http.method
 * Change http.url to follow [OpenTelemetry http spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client).
   Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment].
   Must not contain credentials passed via URL.

--- a/instrumentation/opentelemetry_req/CHANGELOG.md
+++ b/instrumentation/opentelemetry_req/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+* Change span_name to follow [OpenTelemetry http spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#name)
 * Use span_name if provided, otherwise use path_params. If there are no
   path_params, default to request path
+* Change http.url to follow [OpenTelemetry http spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client).
+  Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment].
+  Must not contain credentials passed via URL.
 
 ## 0.1.2
 

--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -182,14 +182,6 @@ defmodule OpentelemetryReq do
     end
   end
 
-  defp url(uri) do
-    if uri.query do
-      uri.path <> "?" <> uri.query
-    else
-      uri.path
-    end
-  end
-
   defp http_method(method) do
     case method do
       :get -> :GET

--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -106,7 +106,9 @@ defmodule OpentelemetryReq do
   defp format_exception(_), do: ""
 
   defp span_name(request) do
-    Req.Request.get_private(request, :path_params_template)
+    Req.Request.get_private(request, :span_name) ||
+      Req.Request.get_private(request, :path_params_template) ||
+      request.url.path
   end
 
   defp build_req_attrs(request) do

--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -122,14 +122,16 @@ defmodule OpentelemetryReq do
   defp format_exception(_), do: ""
 
   defp span_name(request) do
-    route =
-      Req.Request.get_private(request, :span_name) ||
-        Req.Request.get_private(request, :path_params_template) ||
-        request.url.path
+    case request.options[:span_name] do
+      nil ->
+        route = Req.Request.get_private(request, :path_params_template) || request.url.path
 
-    method = http_method(request.method)
+        method = http_method(request.method)
+        "#{method} #{route}"
 
-    "#{method} #{route}"
+      span_name ->
+        span_name
+    end
   end
 
   defp build_req_attrs(request) do

--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -124,10 +124,12 @@ defmodule OpentelemetryReq do
   defp span_name(request) do
     case request.options[:span_name] do
       nil ->
-        route = Req.Request.get_private(request, :path_params_template) || request.url.path
-
         method = http_method(request.method)
-        "#{method} #{route}"
+
+        case Req.Request.get_private(request, :path_params_template) do
+          nil -> method
+          params_template -> "#{method} #{params_template}"
+        end
 
       span_name ->
         span_name

--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -5,17 +5,20 @@ defmodule OpentelemetryReq do
   expected by default and an error will be raised if the path params option is
   not set for the request.
 
-  Given the steps pipeline can be halted to skip further steps from running, it is important
-  to _append_ request and response steps _after_ this step to ensure execution. Spans are not
-  created until the request is completed or errored.
+  Spans are not created until the request is completed or errored.
 
-  ### Example
+  ## Request Options
+
+    * `:span_name` - `String.t()` if provided, overrides the span name. Defaults to `nil`.
+    * `:no_path_params` - `boolean()` when set to `true` no path params are expected for the request. Defaults to `false`
+    * `:propagate_trace_ctx` - `boolean()` when set to `true`, trace headers will be propagated. Defaults to `false`
+
+  ### Example with path_params
 
   ```
   client =
     Req.new()
-    |> OpentelemetryReq.attach()
-    |> Req.Request.merge_options(
+    |> OpentelemetryReq.attach(
       base_url: "http://localhost:4000",
       propagate_trace_ctx: true
     )
@@ -26,11 +29,24 @@ defmodule OpentelemetryReq do
     path_params: [user_id: user_id]
   )
   ```
-  ## Request Options
 
-    * `:span_name` - `String.t()` if provided, overrides the span name. Defaults to `nil`.
-    * `:no_path_params` - `boolean()` when set to `true` no path params are expected for the request. Defaults to `false`
-    * `:propagate_trace_ctx` - `boolean()` when set to `true`, trace headers will be propagated. Defaults to `false`
+  ### Example without path_params
+
+  ```
+  client =
+    Req.new()
+    |> OpentelemetryReq.attach(
+      base_url: "http://localhost:4000",
+      propagate_trace_ctx: true,
+      no_path_params: true
+    )
+
+  client
+  |> Req.get(
+    url: "/api/users"
+  )
+  ```
+  If you don't set `path_params` the request will raise.
   """
 
   alias OpenTelemetry.Tracer


### PR DESCRIPTION
- Span name now follows [http span spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#name)
  - Span name defaults to `:path_params_template` or if there is no path_params it gets the `request.url.path`
- Http.url now follows [http.url spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client)
- Override span_name if is provided in the request options