### PR TITLE
Don't record DB statements without sanitizaiton

### DIFF
--- a/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
+++ b/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
@@ -105,8 +105,10 @@ defmodule OpentelemetryEcto do
       case Keyword.fetch(config, :db_statement) do
         {:ok, :enabled} ->
           Map.put(base_attributes, :"db.statement", query)
+
         {:ok, :disabled} ->
           base_attributes
+
         {:ok, sanitizer} ->
           Map.put(base_attributes, :"db.statement", sanitizer.(query))
 

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -50,8 +50,6 @@ defmodule OpentelemetryEctoTest do
 
     assert %{
              "db.instance": "opentelemetry_ecto_test",
-             "db.name": "opentelemetry_ecto_test",
-             "db.statement": "SELECT u0.\"id\", u0.\"email\" FROM \"users\" AS u0",
              "db.type": :sql,
              "db.url": "ecto://localhost",
              decode_time_microseconds: _,
@@ -60,6 +58,14 @@ defmodule OpentelemetryEctoTest do
              source: "users",
              total_time_microseconds: _
            } = :otel_attributes.map(attributes)
+  end
+
+  test "include sanitized query" do
+    attach_handler(query_sanitizer: fn query -> query end)
+    Repo.all(User)
+
+    assert_receive {:span, span(attributes: attributes)}
+    assert %{"db.statement": "SELECT u0.\"id\", u0.\"email\" FROM \"users\" AS u0"} = :otel_attributes.map(attributes)
   end
 
   test "include additionaL_attributes" do
@@ -83,8 +89,6 @@ defmodule OpentelemetryEctoTest do
 
     assert %{
              "db.instance": "opentelemetry_ecto_test",
-             "db.name": "opentelemetry_ecto_test",
-             "db.statement": "SELECT p0.\"id\", p0.\"body\", p0.\"user_id\" FROM \"posts\" AS p0",
              "db.type": :sql,
              "db.url": "ecto://localhost",
              decode_time_milliseconds: _,

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -77,7 +77,7 @@ defmodule OpentelemetryEctoTest do
   end
 
   test "include santized query with sanitizer function" do
-    attach_handler(db_statement: fn (str) -> String.replace(str, "SELECT", "") end)
+    attach_handler(db_statement: fn str -> String.replace(str, "SELECT", "") end)
     Repo.all(User)
 
     assert_receive {:span, span(attributes: attributes)}


### PR DESCRIPTION
This adds an option to OpentelemetryEcto.setup/1 that allows a query sanitization function to be provided. If it is not provided, queries are not captured (this is the default). This resolves #155 .