### PR TITLE
Add source_url_pattern to enable linking to source

### DIFF
--- a/instrumentation/opentelemetry_dataloader/mix.exs
+++ b/instrumentation/opentelemetry_dataloader/mix.exs
@@ -13,7 +13,13 @@ defmodule OpentelemetryDataloader.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       source_url:
-        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_dataloader"
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_dataloader",
+      docs: [
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_dataloader/%{path}#L%{line}",
+        main: "OpentelemetryDataloader",
+        extras: ["README.md"]
+      ]
     ]
   end
 

--- a/instrumentation/opentelemetry_ecto/mix.exs
+++ b/instrumentation/opentelemetry_ecto/mix.exs
@@ -13,7 +13,13 @@ defmodule OpentelemetryEcto.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       source_url:
-        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto"
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto",
+      docs: [
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_ecto/%{path}#L%{line}",
+        main: "OpentelemetryEcto",
+        extras: ["README.md"]
+      ]
     ]
   end
 

--- a/instrumentation/opentelemetry_finch/mix.exs
+++ b/instrumentation/opentelemetry_finch/mix.exs
@@ -12,7 +12,13 @@ defmodule OpentelemetryFinch.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       source_url:
-        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_finch"
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_finch",
+      docs: [
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_finch/%{path}#L%{line}",
+        main: "OpentelemetryFinch",
+        extras: ["README.md"]
+      ]
     ]
   end
 

--- a/instrumentation/opentelemetry_nebulex/mix.exs
+++ b/instrumentation/opentelemetry_nebulex/mix.exs
@@ -12,7 +12,13 @@ defmodule OpentelemetryNebulex.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       source_url:
-        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_nebulex"
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_nebulex",
+      docs: [
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_nebulex/%{path}#L%{line}",
+        main: "OpentelemetryNebulex",
+        extras: ["README.md"]
+      ]
     ]
   end
 

--- a/instrumentation/opentelemetry_oban/mix.exs
+++ b/instrumentation/opentelemetry_oban/mix.exs
@@ -9,6 +9,8 @@ defmodule OpentelemetryOban.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: [
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_oban/%{path}#L%{line}",
         main: "OpentelemetryOban",
         extras: ["README.md"]
       ],
@@ -24,7 +26,9 @@ defmodule OpentelemetryOban.MixProject do
           "OpenTelemetry.io" => "https://opentelemetry.io"
         },
         files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*)
-      ]
+      ],
+      source_url:
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_oban"
     ]
   end
 

--- a/instrumentation/opentelemetry_phoenix/mix.exs
+++ b/instrumentation/opentelemetry_phoenix/mix.exs
@@ -17,6 +17,8 @@ defmodule OpentelemetryPhoenix.MixProject do
       name: "Opentelemetry Phoenix",
       docs: [
         main: "OpentelemetryPhoenix",
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_phoenix/%{path}#L%{line}",
         extras: ["README.md"]
       ],
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/instrumentation/opentelemetry_redix/mix.exs
+++ b/instrumentation/opentelemetry_redix/mix.exs
@@ -12,7 +12,13 @@ defmodule OpentelemetryRedix.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       source_url:
-        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix"
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix",
+      docs: [
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_redix/%{path}#L%{line}",
+        main: "OpentelemetryRedix",
+        extras: ["README.md"]
+      ]
     ]
   end
 

--- a/instrumentation/opentelemetry_req/mix.exs
+++ b/instrumentation/opentelemetry_req/mix.exs
@@ -11,7 +11,10 @@ defmodule OpentelemetryReq.MixProject do
       deps: deps(),
       name: "Opentelemetry Req",
       docs: [
-        main: "OpentelemetryReq"
+        source_url_pattern:
+          "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_req/%{path}#L%{line}",
+        main: "OpentelemetryReq",
+        extras: ["README.md"]
       ],
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),

--- a/instrumentation/opentelemetry_tesla/README.md
+++ b/instrumentation/opentelemetry_tesla/README.md
@@ -5,7 +5,7 @@ Tesla middleware that creates OpenTelemetry spans and injects tracing headers in
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+The package is [available in Hex](https://hex.pm/packages/opentelemetry_tesla) and can be installed
 by adding `opentelemetry_tesla` to your list of dependencies in `mix.exs`:
 
 ```elixir

--- a/instrumentation/opentelemetry_tesla/mix.exs
+++ b/instrumentation/opentelemetry_tesla/mix.exs
@@ -17,7 +17,9 @@ defmodule OpentelemetryTesla.MixProject do
   defp docs() do
     [
       main: "readme",
-      extras: ["README.md"]
+      extras: ["README.md"],
+      source_url_pattern:
+        "https://github.com/open-telemetry/opentelemetry-erlang-contrib/blob/main/instrumentation/opentelemetry_tesla/%{path}#L%{line}"
     ]
   end
 


### PR DESCRIPTION
Just adding the `source_url_pattern` option for exdoc to opentelemetry_oban, to enable the "Link to source" button in the docs.