### PR TITLE
Add db.name to ecto spans

### DIFF
--- a/instrumentation/opentelemetry_ecto/CHANGELOG.md
+++ b/instrumentation/opentelemetry_ecto/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1
+
+### Changed
+
+* Add db.name to ecto spans
+
 ## 1.1.0
 
 ### Changed

--- a/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
+++ b/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
@@ -92,6 +92,7 @@ defmodule OpentelemetryEcto do
       "db.statement": query,
       source: source,
       "db.instance": database,
+      "db.name": database,
       "db.url": url,
       "total_time_#{time_unit}s": System.convert_time_unit(total_time, :native, time_unit)
     }

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -50,7 +50,7 @@ defmodule OpentelemetryEctoTest do
 
     assert %{
              "db.instance": "opentelemetry_ecto_test",
-             "db.name: "opentelemetry_ecto_test",
+             "db.name": "opentelemetry_ecto_test",
              "db.statement": "SELECT u0.\"id\", u0.\"email\" FROM \"users\" AS u0",
              "db.type": :sql,
              "db.url": "ecto://localhost",

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -50,6 +50,7 @@ defmodule OpentelemetryEctoTest do
 
     assert %{
              "db.instance": "opentelemetry_ecto_test",
+             "db.name: "opentelemetry_ecto_test",
              "db.statement": "SELECT u0.\"id\", u0.\"email\" FROM \"users\" AS u0",
              "db.type": :sql,
              "db.url": "ecto://localhost",
@@ -82,6 +83,7 @@ defmodule OpentelemetryEctoTest do
 
     assert %{
              "db.instance": "opentelemetry_ecto_test",
+             "db.name: "opentelemetry_ecto_test",
              "db.statement": "SELECT p0.\"id\", p0.\"body\", p0.\"user_id\" FROM \"posts\" AS p0",
              "db.type": :sql,
              "db.url": "ecto://localhost",

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -83,7 +83,7 @@ defmodule OpentelemetryEctoTest do
 
     assert %{
              "db.instance": "opentelemetry_ecto_test",
-             "db.name: "opentelemetry_ecto_test",
+             "db.name": "opentelemetry_ecto_test",
              "db.statement": "SELECT p0.\"id\", p0.\"body\", p0.\"user_id\" FROM \"posts\" AS p0",
              "db.type": :sql,
              "db.url": "ecto://localhost",


### PR DESCRIPTION
As per the spec, the db.name attribute is required on database spans. This changes adds it.

Ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes