### PR TITLE
[opentelemetry_tesla] Conditionally override propagator

### DIFF
--- a/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -29,7 +29,7 @@ defmodule Tesla.Middleware.OpenTelemetry do
     OpenTelemetry.Tracer.with_span span_name, %{kind: :client} do
       env
       |> maybe_put_additional_ok_statuses(opts[:mark_status_ok])
-      |> Tesla.put_headers(:otel_propagator_text_map.inject([]))
+      |> maybe_propagate(Keyword.get(opts, :propagate, true))
       |> Tesla.run(next)
       |> set_span_attributes()
       |> handle_result()
@@ -50,6 +50,9 @@ defmodule Tesla.Middleware.OpenTelemetry do
       _ -> URI.parse(env.url).path
     end
   end
+
+  defp maybe_propagate(env, true), do: Tesla.put_headers(env, :otel_propagator_text_map.inject([]))
+  defp maybe_propagate(env, false), do: env
 
   defp maybe_put_additional_ok_statuses(env, [_ | _] = additional_ok_statuses) do
     case env.opts[:additional_ok_statuses] do

--- a/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -54,6 +54,7 @@ defmodule Tesla.Middleware.OpenTelemetry do
   end
 
   defp maybe_propagate(env, :none), do: env
+
   defp maybe_propagate(env, propagator) do
     :otel_propagator_text_map.inject(
       propagator,

--- a/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -12,6 +12,8 @@ defmodule Tesla.Middleware.OpenTelemetry do
 
     - `:span_name` - override span name. Can be a `String` for a static span name,
     or a function that takes the `Tesla.Env` and returns a `String`
+    - `:propagator` - configures trace headers propagation. Setting it to `:none` disables propagation.
+    Defaults to `:otel_propagator_text_map`
     - `:mark_status_ok` - configures spans with a list of expected HTTP error codes to be marked as `ok`,
     not as an error-containing spans
   """
@@ -23,13 +25,15 @@ defmodule Tesla.Middleware.OpenTelemetry do
 
   @behaviour Tesla.Middleware
 
+  @default_propagator :otel_propagator_text_map
+
   def call(env, next, opts) do
     span_name = get_span_name(env, Keyword.get(opts, :span_name))
 
     OpenTelemetry.Tracer.with_span span_name, %{kind: :client} do
       env
       |> maybe_put_additional_ok_statuses(opts[:mark_status_ok])
-      |> maybe_propagate(Keyword.get(opts, :propagate, true))
+      |> maybe_propagate(Keyword.get(opts, :propagator, @default_propagator))
       |> Tesla.run(next)
       |> set_span_attributes()
       |> handle_result()
@@ -51,8 +55,8 @@ defmodule Tesla.Middleware.OpenTelemetry do
     end
   end
 
-  defp maybe_propagate(env, true), do: Tesla.put_headers(env, :otel_propagator_text_map.inject([]))
-  defp maybe_propagate(env, false), do: env
+  defp maybe_propagate(env, :none), do: env
+  defp maybe_propagate(env, propagator), do: Tesla.put_headers(env, propagator.inject([]))
 
   defp maybe_put_additional_ok_statuses(env, [_ | _] = additional_ok_statuses) do
     case env.opts[:additional_ok_statuses] do

--- a/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/instrumentation/opentelemetry_tesla/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -12,8 +12,9 @@ defmodule Tesla.Middleware.OpenTelemetry do
 
     - `:span_name` - override span name. Can be a `String` for a static span name,
     or a function that takes the `Tesla.Env` and returns a `String`
-    - `:propagator` - configures trace headers propagation. Setting it to `:none` disables propagation.
-    Defaults to `:otel_propagator_text_map`
+    - `:propagator` - configures trace headers propagators. Setting it to `:none` disables propagation.
+    Any module that implements `:otel_propagator_text_map` can be used.
+    Defaults to calling `:otel_propagator_text_map.get_text_map_injector/0`
     - `:mark_status_ok` - configures spans with a list of expected HTTP error codes to be marked as `ok`,
     not as an error-containing spans
   """

--- a/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -491,27 +491,32 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
     assert response_size == byte_size(response)
   end
 
-  test "Injects distributed tracing headers" do
-    OpentelemetryTelemetry.start_telemetry_span(
-      "tracer_id",
-      "my_label",
-      %{},
-      %{kind: :client}
-    )
+  describe "trace propagation" do
+    test "injects distributed tracing headers by default" do
+      {:ok, env} = Tesla.get(client(), "/propagate-traces")
 
-    assert {:ok,
-            %Tesla.Env{
-              headers: [
-                {"traceparent", traceparent}
-              ]
-            }} =
-             Tesla.Middleware.OpenTelemetry.call(
-               _env = %Tesla.Env{url: ""},
-               _next = [],
-               _opts = []
-             )
+      assert traceparent = Tesla.get_header(env, "traceparent")
+      assert is_binary(traceparent)
 
-    assert is_binary(traceparent)
+      assert_receive {:span, span(name: _name, attributes: attributes)}
+      assert %{"http.target": "/propagate-traces"} = :otel_attributes.map(attributes)
+    end
+
+    test "optionally disable propagation but keep span report" do
+      {:ok, env} = Tesla.get(client(propagate: false), "/propagate-traces")
+
+      refute Tesla.get_header(env, "traceparent")
+
+      assert_receive {:span, span(name: _name, attributes: attributes)}
+      assert %{"http.target": "/propagate-traces"} = :otel_attributes.map(attributes)
+    end
+  end
+
+  defp client(opts \\ []) do
+    [
+      {Tesla.Middleware.OpenTelemetry, opts},
+    ]
+    |> Tesla.client(fn env -> {:ok, env} end)
   end
 
   defp endpoint_url(port), do: "http://localhost:#{port}/"

--- a/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -503,7 +503,7 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
     end
 
     test "optionally disable propagation but keep span report" do
-      {:ok, env} = Tesla.get(client(propagate: false), "/propagate-traces")
+      {:ok, env} = Tesla.get(client(propagator: :none), "/propagate-traces")
 
       refute Tesla.get_header(env, "traceparent")
 

--- a/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/instrumentation/opentelemetry_tesla/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -514,7 +514,7 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
 
   defp client(opts \\ []) do
     [
-      {Tesla.Middleware.OpenTelemetry, opts},
+      {Tesla.Middleware.OpenTelemetry, opts}
     ]
     |> Tesla.client(fn env -> {:ok, env} end)
   end


### PR DESCRIPTION
This builds on the work of #107 and adds the recommended approach that was mentioned there: setting `propagator: :none` instead of `propagate: false`

leaving room for extending it to support multiple propagators
