### PR TITLE
Add abilty to hide `db.statement` in `opentelemetry_redix`

### DIFF
--- a/instrumentation/opentelemetry_redix/test/opentelemetry_redix_test.exs
+++ b/instrumentation/opentelemetry_redix/test/opentelemetry_redix_test.exs
@@ -22,6 +22,7 @@ defmodule OpentelemetryRedixTest do
 
     on_exit(fn ->
       OpenTelemetry.Tracer.end_span()
+      :telemetry.detach({OpentelemetryRedix, :pipeline_stop})
     end)
   end
 


### PR DESCRIPTION
It's not always necessary/desired to include this attribute, especially as in some cases it can be very long.