### PR TITLE
opentelemetry_req: Don't assume `request.options` is a map

### DIFF
--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -209,12 +209,8 @@ defmodule OpentelemetryReq do
   end
 
   defp require_path_params_option(request) do
-    unless request.options[:no_path_params] do
-      unless Map.has_key?(request.options, :path_params) do
-        {Req.Request.halt(request), __MODULE__.PathParamsOptionError.new()}
-      else
-        request
-      end
+    if !request.options[:no_path_params] and !request.options[:path_params] do
+      {Req.Request.halt(request), __MODULE__.PathParamsOptionError.new()}
     else
       request
     end
@@ -229,7 +225,7 @@ defmodule OpentelemetryReq do
 
     @impl true
     def message(_) do
-      "req_path_params path parameter options must be provided"
+      ":path_params option must be set"
     end
   end
 end


### PR DESCRIPTION
I'm planning to make `request.options` internal representation private (https://github.com/wojtekmach/req/pull/222) though calling `request.options[key]` is still explicitly allowed. I believe this PR keeps the current behaviour for regular usage. The minor change is now we would _not_ raise if someone set `path_params: nil` but note sure how common that'd be. If that's a concern I believe `!is_list(request.options[:path_params])` or `Access.fetch(request.options, :path_params) == :error` would work too.