### PR TITLE
Relax Req's elixir version

### DIFF
--- a/instrumentation/opentelemetry_req/mix.exs
+++ b/instrumentation/opentelemetry_req/mix.exs
@@ -6,7 +6,7 @@ defmodule OpentelemetryReq.MixProject do
       app: :opentelemetry_req,
       description: description(),
       version: "0.1.2",
-      elixir: "~> 1.12",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "Opentelemetry Req",


### PR DESCRIPTION
Failing on the test matrix update PR #188 

I don't know of anything that requires >= 1.12