### PR TITLE
Release drafting

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,11 +47,32 @@ utilities:
 scope-ci:
   - .github/workflows/**
 
+opentelemetry_aws_xray:
+  - utilities/opentelemetry_aws_xray/**/*
+
 opentelemetry_cowboy:
   - instrumentation/opentelemetry_cowboy/**/*
 
+opentelemetry_dataloader:
+  - instrumentation/opentelemetry_dataloader/**/*
+
 opentelemetry_ecto:
   - instrumentation/opentelemetry_ecto/**/*
+
+opentelemetry_elli:
+  - instrumentation/opentelemetry_elli/**/*
+
+opentelemetry_finch:
+  - instrumentation/opentelemetry_finch/**/*
+
+opentelemetry_grpcbox:
+  - instrumentation/opentelemetry_grpcbox/**/*
+
+opentelemetry_httpoison:
+  - instrumentation/opentelemetry_httpoison/**/*
+
+opentelemetry_instrumentation_http:
+  - utilities/opentelemetry_instrumentation_http/**/*
 
 opentelemetry_nebulex:
   - instrumentation/opentelemetry_nebulex/**/*
@@ -71,17 +92,8 @@ opentelemetry_redix:
 opentelemetry_req:
   - instrumentation/opentelemetry_req/**/*
 
-opentelemetry_finch:
-  - instrumentation/opentelemetry_finch/**/*
-
 opentelemetry_telemetry:
   - utilities/opentelemetry_telemetry/**/*
 
 opentelemetry_tesla:
   - instrumentation/opentelemetry_tesla/**/*
-
-opentelemetry_xray:
-  - utilities/opentelemetry_xray/**/*
-
-opentelemetry_instrumentation_http:
-  - utilities/opentelemetry_instrumentation_http/**/*

--- a/.github/release-drafter-templates/opentelemetry-aws-xray.yml
+++ b/.github/release-drafter-templates/opentelemetry-aws-xray.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry AWS X-Ray - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-aws-xray-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-aws-xray-v
+include-paths:
+  - utilities/opentelemetry_aws_xray/src/**/*
+  - utilities/opentelemetry_aws_xray/rebar.*

--- a/.github/release-drafter-templates/opentelemetry-cowboy.yml
+++ b/.github/release-drafter-templates/opentelemetry-cowboy.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Cowboy - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-cowboy-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-cowboy-v
+include-paths:
+  - instrumentation/opentelemetry_cowboy/src/**/*
+  - instrumentation/opentelemetry_cowboy/rebar.*

--- a/.github/release-drafter-templates/opentelemetry-dataloader.yml
+++ b/.github/release-drafter-templates/opentelemetry-dataloader.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Dataloader - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-dataloader-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-dataloader-v
+include-paths:
+  - instrumentation/opentelemetry_dataloader/lib/**/*
+  - instrumentation/opentelemetry_dataloader/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-ecto.yml
+++ b/.github/release-drafter-templates/opentelemetry-ecto.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Ecto - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-ecto-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-ecto-v
+include-paths:
+  - instrumentation/opentelemetry_ecto/lib/**/*
+  - instrumentation/opentelemetry_ecto/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-elli.yml
+++ b/.github/release-drafter-templates/opentelemetry-elli.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Elli - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-elli-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-elli-v
+include-paths:
+  - instrumentation/opentelemetry_elli/src/**/*
+  - instrumentation/opentelemetry_elli/rebar.*

--- a/.github/release-drafter-templates/opentelemetry-finch.yml
+++ b/.github/release-drafter-templates/opentelemetry-finch.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Finch - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-finch-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-finch-v
+include-paths:
+  - instrumentation/opentelemetry_finch/lib/**/*
+  - instrumentation/opentelemetry_finch/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-grpcbox.yml
+++ b/.github/release-drafter-templates/opentelemetry-grpcbox.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry GRPCBox - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-grpcbox-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-grpcbox-v
+include-paths:
+  - instrumentation/opentelemetry_grpcbox/src/**/*
+  - instrumentation/opentelemetry_grpcbox/rebar.*

--- a/.github/release-drafter-templates/opentelemetry-httpoison.yml
+++ b/.github/release-drafter-templates/opentelemetry-httpoison.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry HTTPoison - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-httpoison-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-httpoison-v
+include-paths:
+  - instrumentation/opentelemetry_httpoison/lib/**/*
+  - instrumentation/opentelemetry_httpoison/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-instrumentation-http.yml
+++ b/.github/release-drafter-templates/opentelemetry-instrumentation-http.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Instrumentation HTTP - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-instrumentation-http-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-instrumentation-http-v
+include-paths:
+  - utilities/opentelemetry_instrumentation-http/src/**/*
+  - utilities/opentelemetry_instrumentation-http/rebar.*

--- a/.github/release-drafter-templates/opentelemetry-nebulex.yml
+++ b/.github/release-drafter-templates/opentelemetry-nebulex.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Nebulex - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-nebulex-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-nebulex-v
+include-paths:
+  - instrumentation/opentelemetry_nebulex/lib/**/*
+  - instrumentation/opentelemetry_nebulex/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-oban.yml
+++ b/.github/release-drafter-templates/opentelemetry-oban.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Oban - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-oban-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-oban-v
+include-paths:
+  - instrumentation/opentelemetry_oban/lib/**/*
+  - instrumentation/opentelemetry_oban/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-phoenix.yml
+++ b/.github/release-drafter-templates/opentelemetry-phoenix.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Phoenix - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-phoenix-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-phoenix-v
+include-paths:
+  - instrumentation/opentelemetry_phoenix/lib/**/*
+  - instrumentation/opentelemetry_phoenix/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-process-propagator.yml
+++ b/.github/release-drafter-templates/opentelemetry-process-propagator.yml
@@ -1,0 +1,9 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Process Propagator - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-process-propagator-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-process-propagator-v
+include-paths:
+  - propagators/opentelemetry_process_propagator/src/**/*
+  - propagators/opentelemetry_process_propagator/rebar.*
+  - propagators/opentelemetry_process_propagator/lib/**/*
+  - propagators/opentelemetry_process_propagator/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-redix.yml
+++ b/.github/release-drafter-templates/opentelemetry-redix.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Redix - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-redix-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-redix-v
+include-paths:
+  - instrumentation/opentelemetry_redix/lib/**/*
+  - instrumentation/opentelemetry_redix/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-req.yml
+++ b/.github/release-drafter-templates/opentelemetry-req.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Req - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-req-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-req-v
+include-paths:
+  - instrumentation/opentelemetry_req/lib/**/*
+  - instrumentation/opentelemetry_req/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-telemetry.yml
+++ b/.github/release-drafter-templates/opentelemetry-telemetry.yml
@@ -1,0 +1,9 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Telemetry - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-telemetry-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-telemetry-v
+include-paths:
+  - utilities/opentelemetry_telemetry/src/**/*
+  - utilities/opentelemetry_telemetry/rebar.*
+  - utilities/opentelemetry_telemetry/lib/**/*
+  - utilities/opentelemetry_telemetry/lib/mix.*

--- a/.github/release-drafter-templates/opentelemetry-tesla.yml
+++ b/.github/release-drafter-templates/opentelemetry-tesla.yml
@@ -1,0 +1,7 @@
+_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+name-template: 'Opentelemetry Tesla - v$RESOLVED_VERSION'
+tag-template: 'opentelemetry-tesla-v$RESOLVED_VERSION'
+tag-prefix: opentelemetry-tesla-v
+include-paths:
+  - instrumentation/opentelemetry_tesla/lib/**/*
+  - instrumentation/opentelemetry_tesla/lib/mix.*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'release'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,6 +27,54 @@ jobs:
           matrixStringifiedObject="$(jq -c . .github/elixir-test-matrix.json)"
           echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT
 
+  opentelemetry-dataloader:
+    needs: [test-matrix]
+    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_dataloader'))
+    env:
+      app: "opentelemetry_dataloader"
+    defaults:
+      run:
+        working-directory: instrumentation/${{ env.app }}
+    runs-on: ${{ matrix.os }}
+    name: Opentelemetry Dataloader test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    services:
+      postgres:
+        image: circleci/postgres:13.3-ram
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: opentelemetry_dataloader_test
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          elixir-version: ${{ matrix.elixir_version }}
+          rebar3-version: ${{ matrix.rebar3_version }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/deps
+            ~/_build
+          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
+      - name: Fetch deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - name: Compile project
+        run: mix compile --warnings-as-errors
+      - name: Check formatting
+        run: mix format --check-formatted
+        if: matrix.check_formatted
+      - name: Test
+        run: mix test
+
   opentelemetry-ecto:
     needs: [test-matrix]
     if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_ecto'))
@@ -74,6 +122,82 @@ jobs:
       - name: Test
         run: mix test
 
+  opentelemetry-finch:
+    needs: [test-matrix]
+    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_finch'))
+    env:
+      app: "opentelemetry_finch"
+    defaults:
+      run:
+        working-directory: instrumentation/${{ env.app }}
+    runs-on: ${{ matrix.os }}
+    name: Opentelemetry Finch test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          elixir-version: ${{ matrix.elixir_version }}
+          rebar3-version: ${{ matrix.rebar3_version }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/deps
+            ~/_build
+          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
+      - name: Fetch deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - name: Compile project
+        run: mix compile --warnings-as-errors
+      - name: Check formatting
+        run: mix format --check-formatted
+        if: matrix.check_formatted
+      - name: Test
+        run: mix test
+
+  opentelemetry-httpoison:
+    needs: [test-matrix]
+    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_httpoison'))
+    env:
+      app: "opentelemetry_httpoison"
+    defaults:
+      run:
+        working-directory: instrumentation/${{ env.app }}
+    runs-on: ubuntu-20.04
+    name: Opentelemetry HTTPoison test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          elixir-version: ${{ matrix.elixir_version }}
+          rebar3-version: ${{ matrix.rebar3_version }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/deps
+            ~/_build
+          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
+      - name: Fetch deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - name: Compile project
+        run: mix compile --warnings-as-errors
+      - name: Check formatting
+        run: mix format --check-formatted
+        if: matrix.check_formatted
+      - name: Test
+        run: mix test
+
   opentelemetry-nebulex:
     needs: [test-matrix]
     if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_nebulex'))
@@ -87,6 +211,53 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          elixir-version: ${{ matrix.elixir_version }}
+          rebar3-version: ${{ matrix.rebar3_version }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/deps
+            ~/_build
+          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
+      - name: Fetch deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - name: Compile project
+        run: mix compile --warnings-as-errors
+      - name: Check formatting
+        run: mix format --check-formatted
+        if: matrix.check_formatted
+      - name: Test
+        run: mix test
+
+  opentelemetry-oban:
+    needs: [test-matrix]
+    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_oban'))
+    env:
+      app: "opentelemetry_oban"
+    defaults:
+      run:
+        working-directory: instrumentation/${{ env.app }}
+    runs-on: ${{ matrix.os }}
+    name: Opentelemetry Oban test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    services:
+      postgres:
+        image: circleci/postgres:13.3-ram
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: opentelemetry_oban_test
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -230,44 +401,6 @@ jobs:
       - name: Test
         run: mix test
 
-  opentelemetry-finch:
-    needs: [test-matrix]
-    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_finch'))
-    env:
-      app: "opentelemetry_finch"
-    defaults:
-      run:
-        working-directory: instrumentation/${{ env.app }}
-    runs-on: ${{ matrix.os }}
-    name: Opentelemetry Finch test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp_version }}
-          elixir-version: ${{ matrix.elixir_version }}
-          rebar3-version: ${{ matrix.rebar3_version }}
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/deps
-            ~/_build
-          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
-      - name: Fetch deps
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: mix deps.get
-      - name: Compile project
-        run: mix compile --warnings-as-errors
-      - name: Check formatting
-        run: mix format --check-formatted
-        if: matrix.check_formatted
-      - name: Test
-        run: mix test
-
   opentelemetry-telemetry:
     needs: [test-matrix]
     if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_telemetry'))
@@ -281,101 +414,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp_version }}
-          elixir-version: ${{ matrix.elixir_version }}
-          rebar3-version: ${{ matrix.rebar3_version }}
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/deps
-            ~/_build
-          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
-      - name: Fetch deps
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: mix deps.get
-      - name: Compile project
-        run: mix compile --warnings-as-errors
-      - name: Check formatting
-        run: mix format --check-formatted
-        if: matrix.check_formatted
-      - name: Test
-        run: mix test
-
-  opentelemetry-oban:
-    needs: [test-matrix]
-    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_oban'))
-    env:
-      app: "opentelemetry_oban"
-    defaults:
-      run:
-        working-directory: instrumentation/${{ env.app }}
-    runs-on: ${{ matrix.os }}
-    name: Opentelemetry Oban test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
-    services:
-      postgres:
-        image: circleci/postgres:13.3-ram
-        ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: opentelemetry_oban_test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp_version }}
-          elixir-version: ${{ matrix.elixir_version }}
-          rebar3-version: ${{ matrix.rebar3_version }}
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/deps
-            ~/_build
-          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
-      - name: Fetch deps
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: mix deps.get
-      - name: Compile project
-        run: mix compile --warnings-as-errors
-      - name: Check formatting
-        run: mix format --check-formatted
-        if: matrix.check_formatted
-      - name: Test
-        run: mix test
-
-  opentelemetry-dataloader:
-    needs: [test-matrix]
-    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_dataloader'))
-    env:
-      app: "opentelemetry_dataloader"
-    defaults:
-      run:
-        working-directory: instrumentation/${{ env.app }}
-    runs-on: ${{ matrix.os }}
-    name: Opentelemetry Dataloader test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
-    services:
-      postgres:
-        image: circleci/postgres:13.3-ram
-        ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: opentelemetry_dataloader_test
-
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -449,44 +487,6 @@ jobs:
         working-directory: instrumentation/${{ env.app }}
     runs-on: ${{ matrix.os }}
     name: Opentelemetry Tesla test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp_version }}
-          elixir-version: ${{ matrix.elixir_version }}
-          rebar3-version: ${{ matrix.rebar3_version }}
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/deps
-            ~/_build
-          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-v3-${{ hashFiles('**/mix.lock') }}
-      - name: Fetch deps
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: mix deps.get
-      - name: Compile project
-        run: mix compile --warnings-as-errors
-      - name: Check formatting
-        run: mix format --check-formatted
-        if: matrix.check_formatted
-      - name: Test
-        run: mix test
-
-  opentelemetry-httpoison:
-    needs: [test-matrix]
-    if: (contains(github.event.pull_request.labels.*.name, 'elixir') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_httpoison'))
-    env:
-      app: "opentelemetry_httpoison"
-    defaults:
-      run:
-        working-directory: instrumentation/${{ env.app }}
-    runs-on: ubuntu-20.04
-    name: Opentelemetry HTTPoison test on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }})
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -27,6 +27,37 @@ jobs:
           matrixStringifiedObject="$(jq -c . .github/erlang-test-matrix.json)"
           echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT
 
+  opentelemetry-aws-xray:
+    needs: [test-matrix]
+    if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_aws_xray'))
+    env:
+      app: "opentelemetry_aws_xray"
+    defaults:
+      run:
+        working-directory: utilities/${{ env.app }}
+    runs-on: ${{ matrix.os }}
+    name: Opentelemetry AWS X-Ray test on OTP ${{ matrix.otp_version }} with Rebar3 ${{ matrix.rebar3_version }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          rebar3-version: ${{ matrix.rebar3_version }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/_build
+          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.rebar3_version }}-v3-${{ hashFiles('**/rebar.lock') }}
+      - name: Fetch deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: rebar3 get-deps
+      - name: Test
+        run: rebar3 ct
+
   opentelemetry-cowboy:
     needs: [test-matrix]
     if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_cowboy'))
@@ -58,16 +89,16 @@ jobs:
       - name: Test
         run: rebar3 ct
 
-  opentelemetry-telemetry:
+  opentelemetry-elli:
     needs: [test-matrix]
-    if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_telemetry'))
+    if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_elli'))
     env:
-      app: "opentelemetry_telemetry"
+      app: "opentelemetry_elli"
     defaults:
       run:
-        working-directory: utilities/${{ env.app }}
+        working-directory: instrumentation/${{ env.app }}
     runs-on: ${{ matrix.os }}
-    name: Opentelemetry Telemetry test on OTP ${{ matrix.otp_version }} with Rebar3 ${{ matrix.rebar3_version }}
+    name: Opentelemetry Elli test on OTP ${{ matrix.otp_version }} with Rebar3 ${{ matrix.rebar3_version }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
@@ -89,16 +120,16 @@ jobs:
       - name: Test
         run: rebar3 ct
 
-  opentelemetry-aws-xray:
+  opentelemetry-grpcbox:
     needs: [test-matrix]
-    if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_aws_xray'))
+    if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_grpcbox'))
     env:
-      app: "opentelemetry_aws_xray"
+      app: "opentelemetry_grpcbox"
     defaults:
       run:
-        working-directory: utilities/${{ env.app }}
+        working-directory: instrumentation/${{ env.app }}
     runs-on: ${{ matrix.os }}
-    name: Opentelemetry AWS X-Ray test on OTP ${{ matrix.otp_version }} with Rebar3 ${{ matrix.rebar3_version }}
+    name: Opentelemetry GRPCBox test on OTP ${{ matrix.otp_version }} with Rebar3 ${{ matrix.rebar3_version }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
@@ -150,3 +181,34 @@ jobs:
         run: rebar3 get-deps
       - name: Test
         run: rebar3 eunit
+
+  opentelemetry-telemetry:
+    needs: [test-matrix]
+    if: (contains(github.event.pull_request.labels.*.name, 'erlang') && contains(github.event.pull_request.labels.*.name, 'opentelemetry_telemetry'))
+    env:
+      app: "opentelemetry_telemetry"
+    defaults:
+      run:
+        working-directory: utilities/${{ env.app }}
+    runs-on: ${{ matrix.os }}
+    name: Opentelemetry Telemetry test on OTP ${{ matrix.otp_version }} with Rebar3 ${{ matrix.rebar3_version }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          rebar3-version: ${{ matrix.rebar3_version }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/_build
+          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ matrix.rebar3_version }}-v3-${{ hashFiles('**/rebar.lock') }}
+      - name: Fetch deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: rebar3 get-deps
+      - name: Test
+        run: rebar3 ct

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,177 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  opentelemetry-aws-xray-release:
+    name: '[opentelemetry-aws-xray-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-aws-xray.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-cowboy-release:
+    name: '[opentelemetry-cowboy-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-cowboy.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-dataloader-release:
+    name: '[opentelemetry-dataloader-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-dataloader.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-ecto-release:
+    name: '[opentelemetry-ecto-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-ecto.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-elli-release:
+    name: '[opentelemetry-elli-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-elli.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-finch-release:
+    name: '[opentelemetry-finch-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-finch.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-grpcbox-release:
+    name: '[opentelemetry-grpcbox-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-grpcbox.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-httpoison-release:
+    name: '[opentelemetry-httpoison-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-httpoison.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-instrumentation-http-release:
+    name: '[opentelemetry-instrument-http-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-instrumentation-http.yml
+        env:
+
+  opentelemetry-nebulex-release:
+    name: '[opentelemetry-nebulex-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-nebulex.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-oban-release:
+    name: '[opentelemetry-oban-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-oban.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-phoenix-release:
+    name: '[opentelemetry-phoenix-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-phoenix.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-process-propagator-release:
+    name: '[opentelemetry-process-propagator-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-process-propagator.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-redix-release:
+    name: '[opentelemetry-redix-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-redix.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-req-release:
+    name: '[opentelemetry-req-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-req.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-telemetry-release:
+    name: '[opentelemetry-telemetry-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-telemetry.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opentelemetry-tesla-release:
+    name: '[opentelemetry-tesla-release] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-templates/opentelemetry-tesla.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Setting up monorepo release drafting to get tagging and automated release notes. We can maybe use this as a foundation for automating some other things when cutting releases since we'll have tags to work with in combo with the new tag-related rulesets.

Added missing test suites, labels, and re-alphabetized the actions file contents. I plan to refactor some of the test jobs to using shared workflows to make maintenance easier.