### PR TITLE
Revert span name change to pre-1.18 spec

### DIFF
--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -127,8 +127,8 @@ defmodule OpentelemetryReq do
         method = http_method(request.method)
 
         case Req.Request.get_private(request, :path_params_template) do
-          nil -> method
-          params_template -> "#{method} #{params_template}"
+          nil -> "HTTP #{method}"
+          params_template -> "#{params_template}"
         end
 
       span_name ->


### PR DESCRIPTION
Reverting span name format change [per discussion](https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/194#issuecomment-1706889660) to unblock a release to support Req >= 0.4