### PR TITLE
Fix documentation example for OpentelemetryProcessPropagator

### DIFF
--- a/propagators/opentelemetry_process_propagator/lib/opentelemetry_process_propagator.ex
+++ b/propagators/opentelemetry_process_propagator/lib/opentelemetry_process_propagator.ex
@@ -50,7 +50,7 @@ defmodule OpentelemetryProcessPropagator do
     # you don't control, e.g. Ecto preloads
 
     Task.async(fn ->
-      parent_ctx = OpentelemetryProcessPropagator.fetch_parent_ctx(:"$callers")
+      parent_ctx = OpentelemetryProcessPropagator.fetch_parent_ctx(1, :"$callers")
 
       OpenTelemetry.Ctx.attach(parent_ctx)
 


### PR DESCRIPTION
I might have got things wrong, but reading the documentation and the code it seems that the doc was wrong, so I'm opening this really small PR to fix that. Hopefully you dont mind ❤️ 

The example calling `OpentelemetryProcessPropagator.fetch_parent_ctx` was passing the key to the `/1` arity function, which is not the argument it expects. To specify the key you also need to specify the depth first, using the `/2` arity function: `OpentelemetryProcessPropagator.fetch_parent_ctx(depth, key)`