### PR TITLE
Start telemetry span for liveview

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -278,6 +278,13 @@ defmodule OpentelemetryPhoenix do
 
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
+      inspect(live_view),
+      meta,
+      %{kind: :server}
+    )
+
+    OpentelemetryTelemetry.start_telemetry_span(
+      @tracer_id,
       "#{inspect(live_view)}.mount",
       meta,
       %{kind: :server}


### PR DESCRIPTION
Because:
Instead of just on the mount of a liveview we also want to start a telemetry on the liveview.

This follows from trying to check the current span/trace id on a liveview page where the handle_params did a Proces.send_after/3. After the handle_info/2 was executed the current_span could not be gotten with OpenTelemetry.Tracer.current_span_ctx() which returned `:undefined`.

The addition of this commit makes that current_span_ctx/0 returns the the same span after the handle_info we as we did on the mount.

I'm not sure how to test the failing behavior in the current test setup, so I'd love to have some pointers for that.