### PR TITLE
Process Propagator: Allow looking up parent when parent is a named process

### DIFF
--- a/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
+++ b/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
@@ -39,7 +39,12 @@ fetch_ctx(Pid) ->
             otel_ctx(Dictionary)
     end.
 
--spec pdict(pid()) -> [{term(), term()}] | undefined.
+-spec pdict(pid() | atom()) -> [{term(), term()}] | undefined.
+pdict(Name) when is_atom(Name) ->
+    case whereis(Name) of
+        undefined -> undefined;
+        Pid -> pdict(Pid)
+    end;
 pdict(Pid) ->
     case process_info(Pid, dictionary) of
         {dictionary, Dict} ->

--- a/propagators/opentelemetry_process_propagator/test/opentelemetry_process_propagator_test.exs
+++ b/propagators/opentelemetry_process_propagator/test/opentelemetry_process_propagator_test.exs
@@ -55,6 +55,24 @@ defmodule OpentelemetryProcessPropagatorTest do
 
       assert_receive ^ctx
     end
+
+    test "fetches the parent ctx when parent is named" do
+      Process.register(self(), TestParent)
+
+      span_ctx = Tracer.start_span("test")
+      Tracer.set_current_span(span_ctx)
+
+      ctx = Ctx.get_current()
+
+      pid = self()
+
+      :proc_lib.spawn(fn ->
+        p_ctx = fetch_parent_ctx()
+        send(pid, p_ctx)
+      end)
+
+      assert_receive ^ctx
+    end
   end
 
   describe "fetch_parent_ctx/1" do


### PR DESCRIPTION
It seems like sometimes the ancestor field in the pdict contains both pids and named processes. I've noticed this in particular with Broadway.