### PR TITLE
Remove unnecessary Oban defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We'd love your help!. Use tags [up-for-grabs][up-for-grabs-issues] and
 
 - For more information on OpenTelemetry, see [opentelemetry.io](https://opentelemetry.io).
 - For conventions used in OpenTelemetry traces, see the following [readme](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md).
-- For help or feedback on this project, join us in [GitHub Discussions](https://github.com/open-telemetry/opentelemetry-erlang-contrib/discussions), `#otel-erlang-elixir` channel in the [CNCF slack](https://slack.cncf.io/), and `#opentelemetry` channel in the [Elixir Lang slack](https://elixir-slackin.herokuapp.com/)
+- For help or feedback on this project, join us in [GitHub Discussions](https://github.com/open-telemetry/opentelemetry-erlang-contrib/discussions), `#otel-erlang-elixir` channel in the [CNCF slack](https://slack.cncf.io/), and `#opentelemetry` channel in the [Elixir Lang slack](https://elixir-slack.community/)
 - Erlang SIG [community page](https://github.com/open-telemetry/community#special-interest-groups)
 
 ## License

--- a/examples/basic_phoenix_ecto/lib/demo_web/templates/page/index.html.heex
+++ b/examples/basic_phoenix_ecto/lib/demo_web/templates/page/index.html.heex
@@ -31,7 +31,7 @@
         <a href="https://twitter.com/elixirphoenix">Twitter @elixirphoenix</a>
       </li>
       <li>
-        <a href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a>
+        <a href="https://elixir-slack.community/">Elixir on Slack</a>
       </li>
       <li>
         <a href="https://discord.gg/elixir">Elixir on Discord</a>

--- a/instrumentation/opentelemetry_oban/lib/opentelemetry_oban.ex
+++ b/instrumentation/opentelemetry_oban/lib/opentelemetry_oban.ex
@@ -53,7 +53,7 @@ defmodule OpentelemetryOban do
 
   def insert(name \\ Oban, %Changeset{} = changeset) do
     attributes = attributes_before_insert(changeset)
-    worker = Changeset.get_field(changeset, :worker, "unknown")
+    worker = Changeset.get_field(changeset, :worker)
 
     OpenTelemetry.Tracer.with_span "#{worker} send", attributes: attributes, kind: :producer do
       changeset = add_tracing_information_to_meta(changeset)
@@ -75,7 +75,7 @@ defmodule OpentelemetryOban do
 
   def insert!(name \\ Oban, %Changeset{} = changeset) do
     attributes = attributes_before_insert(changeset)
-    worker = Changeset.get_field(changeset, :worker, "unknown")
+    worker = Changeset.get_field(changeset, :worker)
 
     OpenTelemetry.Tracer.with_span "#{worker} send", attributes: attributes, kind: :producer do
       changeset = add_tracing_information_to_meta(changeset)
@@ -126,8 +126,8 @@ defmodule OpentelemetryOban do
   end
 
   defp attributes_before_insert(changeset) do
-    queue = Changeset.get_field(changeset, :queue, "unknown")
-    worker = Changeset.get_field(changeset, :worker, "unknown")
+    queue = Changeset.get_field(changeset, :queue)
+    worker = Changeset.get_field(changeset, :worker)
 
     %{
       Trace.messaging_system() => :oban,


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary Oban defaults. These fields are required in `Oban.Job`
Fix Slack link

