### PR TITLE
Set minor as default semver type

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,7 @@ version-resolver:
   patch:
     labels:
       - 'patch'
-  default: patch
+  default: minor
 exclude-labels:
   - 'skip-changelog'
 template: |


### PR DESCRIPTION
Setting the default version type as `minor` to avoid the breaking change issue that happened with the last ecto release.