### PR TITLE
Fix typos

### DIFF
--- a/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
+++ b/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
@@ -61,7 +61,7 @@ defmodule OpentelemetryEcto do
       `"blog.repo.query"`. This will always be followed with a colon and the
       source (the table name for SQL adapters). For example: `"blog.repo.query:users"`.
     * `:additional_attributes` - additional attributes to include in the span. If there
-      are conflits with default provided attributes, the ones provided with
+      are conflicts with default provided attributes, the ones provided with
       this config will have precedence.
     * `:db_statement` - `:disabled` (default), `:enabled`, or a function.
       Whether or not to include DB statements in the **span attributes** (as the

--- a/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
+++ b/instrumentation/opentelemetry_ecto/test/opentelemetry_ecto_test.exs
@@ -79,7 +79,7 @@ defmodule OpentelemetryEctoTest do
              :otel_attributes.map(attributes)
   end
 
-  test "include santized query with sanitizer function" do
+  test "include sanitized query with sanitizer function" do
     attach_handler(db_statement: fn str -> String.replace(str, "SELECT", "") end)
     Repo.all(User)
 
@@ -150,7 +150,7 @@ defmodule OpentelemetryEctoTest do
     attach_handler()
 
     try do
-      Repo.all(from(u in "users", select: u.non_existant_field))
+      Repo.all(from(u in "users", select: u.non_existent_field))
     rescue
       _ -> :ok
     end
@@ -161,7 +161,7 @@ defmodule OpentelemetryEctoTest do
                       status: {:status, :error, message}
                     )}
 
-    assert message =~ "non_existant_field does not exist"
+    assert message =~ "non_existent_field does not exist"
   end
 
   test "preloads in sequence are tied to the parent span" do

--- a/instrumentation/opentelemetry_httpoison/lib/opentelemetry_httpoison.ex
+++ b/instrumentation/opentelemetry_httpoison/lib/opentelemetry_httpoison.ex
@@ -100,7 +100,7 @@ defmodule OpentelemetryHTTPoison do
   If this behavior is not desirable, it can be set directly as a string or a function
   with an arity of 1 (the `t:HTTPoison.Request/0` `request`) by using the aforementioned `:ot_resource_route` option.
 
-  It can also be circumvented entirely by suppling `:ignore`  instead.
+  It can also be circumvented entirely by supplying `:ignore`  instead.
 
     ## Examples
 

--- a/instrumentation/opentelemetry_redix/test/opentelemetry_redix_test.exs
+++ b/instrumentation/opentelemetry_redix/test/opentelemetry_redix_test.exs
@@ -48,7 +48,7 @@ defmodule OpentelemetryRedixTest do
            } = :otel_attributes.map(attributes)
   end
 
-  test "records span on piplines" do
+  test "records span on pipelines" do
     OpentelemetryRedix.setup()
 
     conn = start_supervised!({Redix, []})

--- a/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
+++ b/instrumentation/opentelemetry_req/lib/opentelemetry_req.ex
@@ -1,6 +1,6 @@
 defmodule OpentelemetryReq do
   @moduledoc """
-  Wraps the request in an opentelemetry span. Span names must be paramaterized, so the
+  Wraps the request in an opentelemetry span. Span names must be parameterized, so the
   `req_path_params` module and step should be registered before this step. This step is
   expected by default and an error will be raised if the path params option is
   not set for the request.

--- a/utilities/opentelemetry_instrumentation_http/CHANGELOG.md
+++ b/utilities/opentelemetry_instrumentation_http/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Changed
 
-* Expose `extract_headers_attributes/3` and `normalize_header_name/1` fucntions to extracted selected headers in an attribute map following semantic conventions
+* Expose `extract_headers_attributes/3` and `normalize_header_name/1` functions to extracted selected headers in an attribute map following semantic conventions


### PR DESCRIPTION
Found via `codespell -H -L statics,smove` and `typos --hidden --format brief`