### PR TITLE
Handle empty stack in pop_from_tracer_stack

### DIFF
--- a/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
+++ b/utilities/opentelemetry_telemetry/src/otel_telemetry.erl
@@ -112,7 +112,11 @@ pop_from_tracer_stack(TracerId) ->
             undefined;
         [SpanCtxSet | Rest] ->
             erlang:put({otel_telemetry, TracerId}, Rest),
-            SpanCtxSet
+            SpanCtxSet;
+        [] ->
+            ?LOG_DEBUG("`opentelemetry_telemetry` span ctx tracer stack for "
+                       "TracerId ~p in Pid ~p is empty.", [TracerId, self()]),
+            undefined
     end.
 
 handle_event(_Event,


### PR DESCRIPTION
Similiar to https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/205
empty stack happens in pop_from_tracer_stack function

Having not this case handled is causing telemetry handler to detach
It originated from opentelemetry_cowboy,

Stack:

```
Telemetry handler failed: %{reason: {:case_clause, []}, stacktrace: [{:otel_telemetry, :pop_from_tracer_stack, 1, 
[file: ~c"src/otel_telemetry.erl", line: 110]}, {:otel_telemetry, :end_telemetry_span, 2, 
[file: ~c"src/otel_telemetry.erl", line: 49]}, {:opentelemetry_cowboy, :handle_event, 4, 
[file: ~c"/app/deps/opentelemetry_cowboy/src/opentelemetry_cowboy.erl", line: 79]}, {:telemetry, :"-execute/3-fun-0-", 4, 
[file: ~c"/app/deps/telemetry/src/telemetry.erl", line: 160]}, {:lists, :foreach_1, 2, 
[file: ~c"lists.erl", line: 1686]}, {:cowboy_metrics_h, :terminate, 3, 
[file: ~c"/app/deps/cowboy/src/cowboy_metrics_h.erl", line: 302]}, {:cowboy_stream, :terminate, 3, 
[file: ~c"/app/deps/cowboy/src/cowboy_stream.erl", line: 138]}, {:cowboy_http, :stream_call_terminate, 4, 
[file: ~c"/app/deps/cowboy/src/cowboy_http.erl", line: 1391]}, {:cowboy_http, :terminate_all_streams, 3, 
[file: ~c"/app/deps/cowboy/src/cowboy_http.erl", line: 1546]}, {:cowboy_http, :terminate, 2, 
[file: ~c"/app/deps/cowboy/src/cowboy_http.erl", line: 1538]}, {:cowboy_http, :commands, 3, 
[file: ~c"/app/deps/cowboy/src/cowboy_http.erl", line: 1077]}, {:cowboy_http, :loop, 1, 
[file: ~c"/app/deps/cowboy/src/cowboy_http.erl", line: 253]}, {:proc_lib, :init_p_do_apply, 3, 
[file: ~c"proc_lib.erl", line: 241]}], kind: :error, handler_id: :opentelemetry_cowboy_handlers, event_name: [:cowboy, :request, :stop], handler_config: %{}}
```