### PR TITLE
Fix Xandra and Broadway releases

### DIFF
--- a/instrumentation/opentelemetry_broadway/CHANGELOG.md
+++ b/instrumentation/opentelemetry_broadway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1
+
+  * Fix issue with Broadway messages with non-binary data in them.
+
 ## 0.1.0
 
   * Initial release

--- a/instrumentation/opentelemetry_broadway/mix.exs
+++ b/instrumentation/opentelemetry_broadway/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpentelemetryBroadway.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [

--- a/instrumentation/opentelemetry_xandra/mix.exs
+++ b/instrumentation/opentelemetry_xandra/mix.exs
@@ -11,7 +11,7 @@ defmodule OpentelemetryXandra.MixProject do
       app: :opentelemetry_xandra,
       description: @description,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
 


### PR DESCRIPTION
For Xandra, the issue is that Xandra requires Elixir 1.15+ but we want to support 1.14+. I think it's fine, the lib will still publish I believe.

For Broadway, the issue is that there is already a 0.1.0 release, so bumping should be enough.