### PR TITLE
feat: read db operation name from telemetry_options

### DIFF
--- a/instrumentation/opentelemetry_ecto/mix.exs
+++ b/instrumentation/opentelemetry_ecto/mix.exs
@@ -64,7 +64,8 @@ defmodule OpentelemetryEcto.MixProject do
       {:ecto_sql, ">= 3.0.0", only: [:dev, :test]},
       {:postgrex, ">= 0.15.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
-      {:opentelemetry_process_propagator, "~> 0.3"}
+      {:opentelemetry_process_propagator, "~> 0.3"},
+      {:opentelemetry_semantic_conventions, "~> 0.2"}
     ]
   end
 end


### PR DESCRIPTION
## Context

Ecto allows to pass `:telemetry_options` as a shared options https://github.com/elixir-ecto/ecto/blob/cba494787b8e98aa0038f6c35e2f44d3661f2620/lib/ecto/repo.ex#L93-L94

I use that to set the `db.operation` OTEL value.