### PR TITLE
opentelemetry_process_propagator: Optimize remote pdict lookup

### DIFF
--- a/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
+++ b/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
@@ -15,7 +15,10 @@ fetch_parent_ctx(MaxDepth) ->
 
 -spec fetch_parent_ctx(non_neg_integer(), atom()) -> otel_ctx:t() | undefined.
 fetch_parent_ctx(MaxDepth, Key) ->
-    Pids = pids(Key, pdict(self())),
+    Pids = case get(Key) of
+        List when is_list(List) -> List;
+        _ -> []
+    end,
     inspect_parent(undefined, lists:sublist(Pids, MaxDepth)).
 
 inspect_parent(Ctx, _Pids) when Ctx =/= undefined ->
@@ -60,12 +63,4 @@ otel_ctx(Dictionary) ->
             undefined;
         {'$__current_otel_ctx', Ctx} ->
             Ctx
-    end.
-
-pids(Key, Dictionary) ->
-    case lists:keyfind(Key, 1, Dictionary) of
-        false ->
-            [];
-        {Key,Pids} ->
-            Pids
     end.


### PR DESCRIPTION
When trying to find a parent context via inspecting another process's dictionary, prior to OTP 26.2, there wasn't a way to fetch only a single key. This means that the entire process dictionary of the ancestor or caller process (which can be arbitrarily large) needs to be copied over to the querying process, so that it can look for the one key it's interested in. This can cause a performance issue on busy systems due to the increased garbage collection overhead of this happening often in many short-lived processes.

OTP 26.2 introduced a new option to `process_info/2` that allows a single key to be queried from the target process, which makes this much more efficient. Since `?OTP_RELEASE` is only defined as the major version, we can unfortunately only take advantage of this for OTP 27 and later. It may be possible to instead query for the version of the `erts` app that includes this functionality, if we decide that's worthwhile, but this PR proposes the simpler option so that it'll be a fast check at compile time, and easy to delete the deprecated code path when we eventually stop supporting OTP 26 and older.

While I was at it, I noticed that there was an inefficient lookup of a key in the current process's own dictionary, which could be optimized by just using `get/1` instead.

I plan to propose a separate PR that makes this "potentially-dangerous" cross-process lookup a no-op via configuration, so that users who can't upgrade to OTP 27 also have an option to work around this performance problem in the meantime. These two things seemed big enough to review and merge separately.

I'm a noob at Erlang, so please let me know if something here is unconventional or poorly-formatted! ❤️ 😅 