### PR TITLE
Instrument batching in opentelemetry_broadway

### DIFF
--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
@@ -186,7 +186,7 @@ defmodule OpentelemetryBroadway do
     } = metadata,
     _config
   ) do
-    status = if length(failed_messages) == 0 do
+    status = if Enum.empty?(failed_messages) do
       OpenTelemetry.status(:ok)
     else
       OpenTelemetry.status(:error, "Batch completed with failed messages")


### PR DESCRIPTION
Hooks into Broadway's batch processor start/stop events to add telemetry support to batching. Uses the the `topology` and `batcher` names to construct the span name. Span `kind` is `:internal`.

Unsurprisingly, `OpenTelemetry.SemanticConventions` has no opinions about attribute names for batch processing. Instead we've namespaced a few novel attributes with `broadway.batch` and include message count, failed message count, and successfully message count.