### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/examples/roll_dice/otel-collector-config.yaml
+++ b/examples/roll_dice/otel-collector-config.yaml
@@ -19,8 +19,8 @@ exporters:
     tls:
       insecure: true
 
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
     sampling_initial: 1
     sampling_thereafter: 1
 
@@ -36,12 +36,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/examples/roll_dice_elli/otel-collector-config.yaml
+++ b/examples/roll_dice_elli/otel-collector-config.yaml
@@ -19,8 +19,8 @@ exporters:
     tls:
       insecure: true
 
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
     sampling_initial: 1
     sampling_thereafter: 1
 
@@ -33,12 +33,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037