### PR TITLE
Bandit: Add the `request_path` to the span name

### DIFF
--- a/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
+++ b/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
@@ -240,7 +240,7 @@ defmodule OpentelemetryBandit do
     name =
       if request_method == HTTPAttributes.http_request_method_values().other,
         do: :HTTP,
-        else: request_method
+        else: String.trim("#{request_method} #{conn.request_path}")
 
     if public_endpoint?(conn, config) do
       propagated_ctx =

--- a/instrumentation/opentelemetry_bandit/test/bandit/opentelemetry_bandit_test.exs
+++ b/instrumentation/opentelemetry_bandit/test/bandit/opentelemetry_bandit_test.exs
@@ -71,7 +71,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /hello",
                         kind: :server,
                         attributes: span_attrs,
                         parent_span_id: 13_235_353_014_750_950_193
@@ -117,7 +117,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /hello",
                         kind: :server,
                         links: links,
                         parent_span_id: :undefined
@@ -152,7 +152,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /hello",
                         kind: :server,
                         links: links,
                         parent_span_id: :undefined
@@ -171,7 +171,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /hello",
                         kind: :server,
                         parent_span_id: 13_235_353_014_750_950_193
                       )}
@@ -208,7 +208,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /with_body",
                         attributes: span_attrs
                       )}
 
@@ -332,7 +332,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /hello",
                         kind: :server,
                         attributes: span_attrs
                       )}
@@ -381,7 +381,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /arithmetic_error",
                         attributes: span_attrs,
                         events: events,
                         status: ^expected_status
@@ -428,7 +428,7 @@ defmodule OpentelemetryBanditTest do
 
       assert_receive {:span,
                       span(
-                        name: :GET,
+                        name: "GET /halted",
                         kind: :server,
                         attributes: span_attrs,
                         status: ^expected_status


### PR DESCRIPTION
The Phoenix instrumentation updates the span name to include the `request_path`, but some requests don't go through the router (like LiveView websocket connections), which means the root span is missing context for what the span is related to.

This PR changes the default Bandit span name to include the `conn.request_path`.