### PR TITLE
Handle bandit start event with no conn

### DIFF
--- a/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
+++ b/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
@@ -262,6 +262,12 @@ defmodule OpentelemetryBandit do
     end
   end
 
+  # error with no conn
+  def handle_request_start(_meta, _config) do
+    Tracer.start_span(:HTTP, %{kind: :server})
+    |> Tracer.set_current_span()
+  end
+
   defp public_endpoint?(_conn, %{public_endpoint: true}), do: true
 
   defp public_endpoint?(conn, %{public_endpoint_fn: {m, f, a}}) do


### PR DESCRIPTION
Handles the situation where bandit emits a telemetry span event and then goes straight to error handling.

Fixes #402