### PR TITLE
delegates type t() to Task.t()

### DIFF
--- a/propagators/opentelemetry_process_propagator/lib/task.ex
+++ b/propagators/opentelemetry_process_propagator/lib/task.ex
@@ -55,6 +55,8 @@ defmodule OpentelemetryProcessPropagator.Task do
   alias OpentelemetryProcessPropagator.Task.Wrapper
   require OpenTelemetry.Tracer
 
+  @type t :: Task.t()
+
   @doc """
   Returns a stream that runs the given function `fun` concurrently
   on each element in `enumerable` with the current `t:OpenTelemetry.Ctx.t/0`


### PR DESCRIPTION
this is kind of silly, but i ran into a typespec error on a function that returns a Task when i aliased `OpentelemetryProcessPropagator.Task`.

```
Unknown type: OpentelemetryProcessPropagator.Task.t/0.
```

also, seems like dialyzer is unhappy on `main`, but i don't understand the issue.

i can test this change locally, but i don't remember how to reference my fork in another project. iirc it's a little different because they're subprojects or w/e?

```
:dialyzer.run error: Analysis failed with error:
{undef,[{prettypr,text,["'undefined'"],[]},
        {cerl_prettypr,lay_ann,2,[{file,"cerl_prettypr.erl"},{line,401}]},
        {cerl_prettypr,format,2,[{file,"cerl_prettypr.erl"},{line,261}]},
        {dialyzer_dataflow,signal_guard_failure,5,
                           [{file,"dialyzer_dataflow.erl"},{line,2477}]},
        {dialyzer_dataflow,bind_guard,3,
                           [{file,"dialyzer_dataflow.erl"},{line,1710}]},
        {dialyzer_dataflow,do_clause,7,
                           [{file,"dialyzer_dataflow.erl"},{line,1268}]},
        {dialyzer_dataflow,handle_clauses,9,
                           [{file,"dialyzer_dataflow.erl"},{line,1199}]},
        {dialyzer_dataflow,handle_case,3,
                           [{file,"dialyzer_dataflow.erl"},{line,932}]}]}
Last messages in the log cache:
  Reading files and computing callgraph... done in 0.02 secs
  Removing edges... done in 0.01 secs
Halting VM with exit status 1
```