### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ doc
 
 .tool-versions
 **/.tool-versions
+
+.DS_Store


### PR DESCRIPTION
Developing on MacOS we have `.DS_Store` files generated for for all directories opened in Finder.