### PR TITLE
Fix OpentelemetryPhoenix tests

### DIFF
--- a/instrumentation/opentelemetry_phoenix/test/integration_test.exs
+++ b/instrumentation/opentelemetry_phoenix/test/integration_test.exs
@@ -170,8 +170,7 @@ if otp_vsn >= 27 do
       }
 
       on_exit(fn ->
-        :telemetry.list_handlers([])
-        |> Enum.each(fn h -> :telemetry.detach(h.id) end)
+        Enum.each(:telemetry.list_handlers([]), &:telemetry.detach(&1.id))
       end)
 
       adapters

--- a/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
+++ b/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
@@ -18,19 +18,18 @@ defmodule OpentelemetryPhoenixTest do
   end
 
   setup do
-    Application.ensure_all_started([:telemetry])
     :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
 
+    OpentelemetryPhoenix.setup(adapter: :cowboy2)
+
     on_exit(fn ->
-      Application.stop(:telemetry)
+      Enum.each(:telemetry.list_handlers([]), &:telemetry.detach(&1.id))
     end)
 
     :ok
   end
 
   test "records spans for Phoenix LiveView mount" do
-    OpentelemetryPhoenix.setup(adapter: :cowboy2)
-
     :telemetry.execute(
       [:phoenix, :live_view, :mount, :start],
       %{system_time: System.system_time()},
@@ -53,8 +52,6 @@ defmodule OpentelemetryPhoenixTest do
   end
 
   test "records spans for Phoenix LiveView handle_params" do
-    OpentelemetryPhoenix.setup(adapter: :cowboy2)
-
     :telemetry.execute(
       [:phoenix, :live_view, :handle_params, :start],
       %{system_time: System.system_time()},
@@ -77,8 +74,6 @@ defmodule OpentelemetryPhoenixTest do
   end
 
   test "records spans for Phoenix LiveView handle_event" do
-    OpentelemetryPhoenix.setup(adapter: :cowboy2)
-
     :telemetry.execute(
       [:phoenix, :live_view, :handle_event, :start],
       %{system_time: System.system_time()},
@@ -101,8 +96,6 @@ defmodule OpentelemetryPhoenixTest do
   end
 
   test "handles exception during Phoenix LiveView handle_params" do
-    OpentelemetryPhoenix.setup(adapter: :cowboy2)
-
     :telemetry.execute(
       [:phoenix, :live_view, :mount, :start],
       %{system_time: System.system_time()},
@@ -160,8 +153,6 @@ defmodule OpentelemetryPhoenixTest do
   end
 
   test "handles exceptions during Phoenix LiveView handle_event" do
-    OpentelemetryPhoenix.setup(adapter: :cowboy2)
-
     :telemetry.execute(
       [:phoenix, :live_view, :handle_event, :start],
       %{system_time: System.system_time()},


### PR DESCRIPTION
Resolves the current failing tests in main. There seems to be some race condition introduced.

Instead of starting and stopping the telemetry app it's easier to just detach all listeners when the test ends.