### PR TITLE
add spec for liveview option to OpentelemetryPhoenix

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -62,13 +62,16 @@ defmodule OpentelemetryPhoenix do
   @tracer_id __MODULE__
 
   @typedoc "Setup options"
-  @type opts :: [endpoint_prefix() | adapter()]
+  @type opts :: [endpoint_prefix() | adapter() | liveview()]
 
   @typedoc "The endpoint prefix in your endpoint. Defaults to `[:phoenix, :endpoint]`"
   @type endpoint_prefix :: {:endpoint_prefix, [atom()]}
 
   @typedoc "The phoenix server adapter being used. Required"
   @type adapter :: {:adapter, :cowboy2 | :bandit}
+
+  @typedoc "Attach LiveView handlers. Optional"
+  @type liveview :: {:liveview, boolean()}
 
   @doc """
   Initializes and configures the telemetry handlers.


### PR DESCRIPTION
very slight spec update to keep dialyzer happy when one calls `OpentelemetryPhoenix.setup(liveview: true)`

before:

```
...
OpentelemetryPhoenix.setup([{:liveview, true}])

breaks the contract
(opts()) :: :ok
________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```

after:

```
...
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m2.81s
done (passed successfully)
```