### PR TITLE
Fix - Crash when propagator fetches context from a remote node

### DIFF
--- a/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
+++ b/propagators/opentelemetry_process_propagator/src/opentelemetry_process_propagator.erl
@@ -42,21 +42,26 @@ fetch_ctx(Name) when is_atom(Name) ->
 fetch_ctx(Pid) when is_pid(Pid) ->
     pdict(Pid).
 
+-spec pdict(pid()) -> otel_ctx:t() | undefined.
 -if(?OTP_RELEASE >= 27).
 %% Fetching a single key from another process's dictionary was introduced in 26.2,
 %% so we can't depend on it until 27.
-pdict(Pid) ->
+pdict(Pid) when node(Pid) =:= node() ->
     case process_info(Pid, {dictionary, '$__current_otel_ctx'}) of
         undefined -> undefined;
         {{dictionary, '$__current_otel_ctx'}, Ctx} -> Ctx
-    end.
+    end;
+pdict(_) ->
+    undefined.
+
 -else.
-pdict(Pid) when is_pid(Pid) ->
+pdict(Pid) when node(Pid) =:= node() ->
     case process_info(Pid, dictionary) of
         undefined -> undefined;
         {dictionary, Dict} -> otel_ctx(Dict)
-    end.
--endif.
+    end;
+pdict(_) ->
+    undefined.
 
 -spec otel_ctx([{term(), term()}]) -> otel_ctx:t() | undefined.
 otel_ctx(Dictionary) ->
@@ -66,3 +71,4 @@ otel_ctx(Dictionary) ->
         {'$__current_otel_ctx', Ctx} ->
             Ctx
     end.
+-endif.


### PR DESCRIPTION
Hello, we've been using opentelemetry_ecto and noticed an issue with the opentelemetry_process_propagator. Whenever a Quantum task runs on a random node in our cluster the telemetry handler gets detached due to the process propagator not handling the `badarg` that gets thrown when it tries to fetch parent context on the remote process:

```
Handler {OpentelemetryEcto, [:persistence, :repo, :query]} has failed and has been detached. Class=:error
Reason=:badarg
Stacktrace=[
  {:erlang, :process_info,
   [#PID<84764.923343.0>, {:dictionary, :"$__current_otel_ctx"}],
   [error_info: %{module: :erl_erts_errors}]},
  {:opentelemetry_process_propagator, :pdict, 1,
   [file: ~c"src/opentelemetry_process_propagator.erl", line: 49]},
  {:opentelemetry_process_propagator, :inspect_parent, 2,
   [file: ~c"src/opentelemetry_process_propagator.erl", line: 29]},
  {OpentelemetryEcto, :handle_event, 4,
   [file: ~c"lib/opentelemetry_ecto.ex", line: 119]},
  {:telemetry, :"-execute/3-fun-0-", 4,
   [file: ~c"/home/app/deps/telemetry/src/telemetry.erl", line: 167]},
  {:lists, :foreach_1, 2, [file: ~c"lists.erl", line: 2310]},
  {Ecto.Adapters.SQL, :log, 4, [file: ~c"lib/ecto/adapters/sql.ex", line: 1234]},
  {DBConnection, :log, 5, [file: ~c"lib/db_connection.ex", line: 1704]},
  {Ecto.Adapters.Postgres.Connection, :prepare_execute, 5,
   [file: ~c"lib/ecto/adapters/postgres/connection.ex", line: 101]},
  {Ecto.Adapters.SQL, :execute!, 5,
   [file: ~c"lib/ecto/adapters/sql.ex", line: 960]},
  {Ecto.Adapters.SQL, :execute, 6,
   [file: ~c"lib/ecto/adapters/sql.ex", line: 952]},
  {Ecto.Repo.Queryable, :execute, 4,
   [file: ~c"lib/ecto/repo/queryable.ex", line: 232]},
  {Ecto.Repo.Queryable, :all, 3,
   [file: ~c"lib/ecto/repo/queryable.ex", line: 19]},
  <redacted>,
  {Quantum.Executor, :"-run/5-fun-2-", 4,
   [file: ~c"lib/quantum/executor.ex", line: 98]},
  {:telemetry, :span, 3,
   [file: ~c"/home/app/deps/telemetry/src/telemetry.erl", line: 324]},
  {Quantum.Executor, :"-run/5-fun-5-", 6,
   [file: ~c"lib/quantum/executor.ex", line: 97]},
  {Task.Supervised, :invoke_mfa, 2,
   [file: ~c"lib/task/supervised.ex", line: 101]},
  {Task.Supervised, :reply, 4, [file: ~c"lib/task/supervised.ex", line: 36]}
]
```

This PR makes it return `undefined` if the process is on a remote node. Also moved the otel_ctx function to avoid an unused function warning when compiling on OTP >= 27
