### PR TITLE
fix: Avoid ignoring Parent Span

### DIFF
--- a/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/job_handler.ex
+++ b/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/job_handler.ex
@@ -57,7 +57,7 @@ defmodule OpentelemetryOban.JobHandler do
     :otel_propagator_text_map.extract(Map.to_list(job_meta))
     parent = OpenTelemetry.Tracer.current_span_ctx()
     links = if parent == :undefined, do: [], else: [OpenTelemetry.link(parent)]
-    OpenTelemetry.Tracer.set_current_span(:undefined)
+    OpenTelemetry.Tracer.set_current_span(parent)
 
     attributes = %{
       Trace.messaging_system() => :oban,


### PR DESCRIPTION
As discussed on #508, `Oban.JobHandler` seems not to be setting the right span, ignoring the parent, causing a break in the traces for a flow. This fix allows the parent span to be included in the traces. 

In case a parent span doesn't exist, it'll have the value `:undefined`, exactly what has been set by default in the current code.