### PR TITLE
Widen allowed semantic_conventions for tesla and oban

### DIFF
--- a/instrumentation/opentelemetry_oban/mix.exs
+++ b/instrumentation/opentelemetry_oban/mix.exs
@@ -47,7 +47,7 @@ defmodule OpentelemetryOban.MixProject do
       {:oban, "~> 2.0"},
       {:opentelemetry_api, "~> 1.2"},
       {:opentelemetry_telemetry, "~> 1.1"},
-      {:opentelemetry_semantic_conventions, "~> 0.2"},
+      {:opentelemetry_semantic_conventions, "~> 0.2 or ~> 1.27"},
       {:opentelemetry, "~> 1.0", only: [:test]},
       {:opentelemetry_exporter, "~> 1.0", only: [:test]},
       {:telemetry, "~> 0.4 or ~> 1.0"},

--- a/instrumentation/opentelemetry_tesla/mix.exs
+++ b/instrumentation/opentelemetry_tesla/mix.exs
@@ -57,7 +57,7 @@ defmodule OpentelemetryTesla.MixProject do
       {:opentelemetry, "~> 1.0", only: :test},
       {:opentelemetry_api, "~> 1.2"},
       {:opentelemetry_telemetry, "~> 1.1"},
-      {:opentelemetry_semantic_conventions, "~> 0.2"},
+      {:opentelemetry_semantic_conventions, "~> 0.2 or ~> 1.27"},
       {:tesla, "~> 1.4"},
       {:ex_doc, "~> 0.37", only: :dev, runtime: false},
       {:bypass, "~> 2.1", only: :test},


### PR DESCRIPTION
Hi!

Thank you for maintaining the project!

I'd like to widen allowed versions of semantic_conventions for tesla and oban.
The reason is, that we are using tesla, oban and cowboy together.
Tesla and Oban depend on v0.2 and cobowy depends on v1.27.
This meant, we were not able to upgrade.

It seems that the upgrade to 1.27 is backwards compatible. We've used
`{:opentelemetry_semantic_conventions, "~> 1.27", override: true}` in our config and both Oban and Tesla work without any issues.

There are other places that still depend on semantic_conventions 0.2:
- basic_phoenix_ecto
- opentelemetry_grpcbox
- opentelemetry_httpoison

If you can confirm that the changes between 0.2 and 1.27 are fully backwards compatible, I could update those places too in one go. However, I am not 100% sure, so I am only updating those that we used in production.