### PR TITLE
Use public interfaces in Bandit module

### DIFF
--- a/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
+++ b/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
@@ -314,12 +314,11 @@ defmodule OpentelemetryBandit do
   end
 
   defp set_network_protocol_attrs(attrs, conn) do
-    case extract_network_protocol(conn.adapter) do
-      {:error, _reason} ->
-        attrs
-
-      {:http, version} ->
-        Map.put(attrs, NetworkAttributes.network_protocol_version(), version)
+    case Plug.Conn.get_http_protocol(conn) do
+      :"HTTP/1.0" -> Map.put(attrs, NetworkAttributes.network_protocol_version(), :"1.0")
+      :"HTTP/1.1" -> Map.put(attrs, NetworkAttributes.network_protocol_version(), :"1.1")
+      :"HTTP/2" -> Map.put(attrs, NetworkAttributes.network_protocol_version(), :"2")
+      _ -> attrs
     end
   end
 
@@ -348,22 +347,6 @@ defmodule OpentelemetryBandit do
         )
     end
   end
-
-  defp extract_network_protocol(
-         {_adapter_name, %{transport: %{__struct__: Bandit.HTTP1.Socket} = transport}}
-       ) do
-    case transport.version do
-      :"HTTP/1.0" -> {:http, :"1.0"}
-      :"HTTP/1.1" -> {:http, :"1.1"}
-      nil -> {:error, "Invalid protocol"}
-    end
-  end
-
-  defp extract_network_protocol({_adapter_name, %{transport: %{__struct__: Bandit.HTTP2.Stream}}}) do
-    {:http, :"2"}
-  end
-
-  defp extract_network_protocol(_), do: {:error, "Invalid protocol"}
 
   defp parse_method(method) do
     case method do

--- a/instrumentation/opentelemetry_bandit/test/bandit/opentelemetry_bandit_test.exs
+++ b/instrumentation/opentelemetry_bandit/test/bandit/opentelemetry_bandit_test.exs
@@ -533,7 +533,7 @@ defmodule OpentelemetryBanditTest do
   end
 
   def arithmetic_error(_conn) do
-    1 / 0
+    apply(:erlang, :+, [1, self()])
   end
 
   def throw_error(_conn) do


### PR DESCRIPTION
Previously, the Bandit support module used non-public interfaces within Bandit to obtain the HTTP protocol version and peer address/port info. These interfaces were factored away in Bandit 1.7, since they were never part of the declared public API. 

This PR updates the Bandit support module to use publicly accessible methods for obtaining this info. 

I've not done any extensive in-situ testing of this, though the suite is green for both Bandit 1.6 and 1.7 versions. 