### PR TITLE
Make spans for live_component update events

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -125,7 +125,10 @@ defmodule OpentelemetryPhoenix do
         [:phoenix, :live_view, :handle_event, :exception],
         [:phoenix, :live_component, :handle_event, :start],
         [:phoenix, :live_component, :handle_event, :stop],
-        [:phoenix, :live_component, :handle_event, :exception]
+        [:phoenix, :live_component, :handle_event, :exception],
+        [:phoenix, :live_component, :update, :start],
+        [:phoenix, :live_component, :update, :stop],
+        [:phoenix, :live_component, :update, :exception]
       ],
       &__MODULE__.handle_liveview_event/4,
       %{}
@@ -197,6 +200,20 @@ defmodule OpentelemetryPhoenix do
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
       "#{inspect(live_view)}.handle_event##{event}",
+      meta,
+      %{kind: :server}
+    )
+  end
+
+  def handle_liveview_event(
+        [:phoenix, :live_component, :update, :start],
+        _measurements,
+        %{component: component} = meta,
+        _handler_configuration
+      ) do
+    OpentelemetryTelemetry.start_telemetry_span(
+      @tracer_id,
+      "#{inspect(component)}.update",
       meta,
       %{kind: :server}
     )


### PR DESCRIPTION
Create spans for LiveComponent updates.

This was the cause of a lot of orphan Ecto spans in my system. Now with this change, these are cleared out.