### PR TITLE
Add otel_http to opentelemetry_cowboy's applications

### DIFF
--- a/instrumentation/opentelemetry_cowboy/src/opentelemetry_cowboy.app.src
+++ b/instrumentation/opentelemetry_cowboy/src/opentelemetry_cowboy.app.src
@@ -7,6 +7,7 @@
     stdlib,
     opentelemetry_api,
     opentelemetry_telemetry,
+    otel_http,
     telemetry
    ]},
   {exclude_paths, ["rebar.lock"]},


### PR DESCRIPTION
This caused issues in our release:

```
function :otel_http.extract_client_info/1 is undefined (module :otel_http is not available)
```

`opentelemetry_req` and `opentelemetry_bandit` both list `otel_http` in their dependencies, but since Mix compiles the `.app.src` file for Elixir projects, both get `otel_http` in their list of applications.

For `opentelemetry_cowboy`, I don't think that happens. To this point, we only see this issue in **releases** and not when compiling and running code locally.