### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ contrib repository must have an OpenTelemetry CNCF Erlang Contrib Approver or Ma
 process. Following approval, the library can be merged and you will be added as a codeowner for it.
 
 This policy has been enacted to be respectful of the maintainers' time and to ensure users get timely responses
-and regular updates. We want as many libraries to be under the official umbrella but need your commmitment to
+and regular updates. We want as many libraries to be under the official umbrella but need your commitment to
 make that happen.
 
 ### CI

--- a/examples/basic_phoenix_ecto/README.md
+++ b/examples/basic_phoenix_ecto/README.md
@@ -11,7 +11,7 @@ Additionally, we also include the OpenTelemetry Collector and
 `opentelemetry_exporter` configuration to
 export the traces to external services like [Honeycomb](https://www.honeycomb.io/) and
 [Lightstep](https://lightstep.com/). Do remember to update the `.env` file to
-include your crendentials if you're doing so.
+include your credentials if you're doing so.
 
 ## Getting Stated
 

--- a/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
+++ b/instrumentation/opentelemetry_ecto/lib/opentelemetry_ecto.ex
@@ -34,7 +34,7 @@ defmodule OpentelemetryEcto do
                       By default, instrumentation libraries implement all `Recommended` attributes in addition
                       to `Required` attributes.
 
-                      Use semantic conventions library to ensure compatability, e.g. `[DBAttributes.db_query_text()]`
+                      Use semantic conventions library to ensure compatibility, e.g. `[DBAttributes.db_query_text()]`
 
                       Recommended Attributes:
                       #{Enum.map_join(opt_outs, "\n\n", &"  * `#{inspect(&1)}`")}
@@ -124,7 +124,7 @@ defmodule OpentelemetryEcto do
 
   Note that attributes can only be additive. Existing attributes will not be overridden. In
   several cases, semantic attributes cannot be reliably set. Where these are not set by
-  this instrumentation, you may still set those attribtutes.
+  this instrumentation, you may still set those attributes.
 
   ```
   Repo.all(User,
@@ -171,7 +171,7 @@ defmodule OpentelemetryEcto do
 
   """
 
-  @typedoc "Use semantic conventions library to ensure compatability, e.g. `DBAttributes.db_query_text()`"
+  @typedoc "Use semantic conventions library to ensure compatibility, e.g. `DBAttributes.db_query_text()`"
   @type opt_out_attr() ::
           unquote(DBAttributes.db_query_text())
 

--- a/instrumentation/opentelemetry_elli/README.md
+++ b/instrumentation/opentelemetry_elli/README.md
@@ -10,7 +10,7 @@ Elli middleware for OpenTelemetry instrumentation.
 {deps, [opentelemetry_elli]}.
 ```
 
-While using the `elli_middleware` callback, place `oc_elli_middelware` as the first module to be called in the list of handlers:
+While using the `elli_middleware` callback, place `oc_elli_middleware` as the first module to be called in the list of handlers:
 
 ``` erlang
 [{callback, elli_middleware},

--- a/instrumentation/opentelemetry_httpoison/test/uri_test.exs
+++ b/instrumentation/opentelemetry_httpoison/test/uri_test.exs
@@ -12,7 +12,7 @@ defmodule OpentelemetryHTTPoison.URITest do
   @base_uri "https://www.test.com"
 
   describe "infer_route_from_request/1" do
-    test "Request URL consisiting of whitespace is inferred as a route of '/'" do
+    test "Request URL consisting of whitespace is inferred as a route of '/'" do
       request = %Request{url: ""}
 
       result = UtilsURI.infer_route_from_request(request)

--- a/instrumentation/opentelemetry_xandra/lib/opentelemetry_xandra.ex
+++ b/instrumentation/opentelemetry_xandra/lib/opentelemetry_xandra.ex
@@ -21,7 +21,7 @@ defmodule OpentelemetryXandra do
   @tracer_id __MODULE__
 
   @typedoc """
-  Thet type for a function that returns the statement to be used in the span.
+  The type for a function that returns the statement to be used in the span.
 
   See `attach/1` for more information.
   """

--- a/utilities/opentelemetry_telemetry/README.md
+++ b/utilities/opentelemetry_telemetry/README.md
@@ -18,7 +18,7 @@ spans, adding attributes, set span names, etc.
 
 This library is only intended to provide utilities for working with telemetry
 events to instrumentation libraries. As such, it should not be used directly
-within your application code where the OpenTelemery API library should be leveraged.
+within your application code where the OpenTelemetry API library should be leveraged.
 
 ## Installation
 


### PR DESCRIPTION
Found via `codespell -L statics,smove,optins` and `typos --hidden --format brief`