### PR TITLE
feat(opentelemetry_phoenix): add controller render tracing

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -23,7 +23,7 @@ defmodule OpentelemetryPhoenix do
   OpentelemetryPhoenix uses [telemetry](https://hexdocs.pm/telemetry/) handlers to create `OpenTelemetry` spans.
 
   Current events which are supported include endpoint start/stop, router start/stop,
-  and router exceptions.
+  router exceptions, LiveView lifecycle events, and controller render events.
 
   ### Supported options
   #{NimbleOptions.docs(@options_schema)}
@@ -87,6 +87,8 @@ defmodule OpentelemetryPhoenix do
       attach_liveview_handlers()
     end
 
+    attach_controller_render_handlers()
+
     :ok
   end
 
@@ -128,6 +130,22 @@ defmodule OpentelemetryPhoenix do
         [:phoenix, :live_component, :handle_event, :exception]
       ],
       &__MODULE__.handle_liveview_event/4,
+      %{}
+    )
+
+    :ok
+  end
+
+  @doc false
+  def attach_controller_render_handlers do
+    :telemetry.attach_many(
+      {__MODULE__, :controller_render},
+      [
+        [:phoenix, :controller, :render, :start],
+        [:phoenix, :controller, :render, :stop],
+        [:phoenix, :controller, :render, :exception]
+      ],
+      &__MODULE__.handle_controller_render_event/4,
       %{}
     )
 
@@ -224,5 +242,52 @@ defmodule OpentelemetryPhoenix do
     OpenTelemetry.Span.record_exception(ctx, exception, stacktrace, [])
     OpenTelemetry.Span.set_status(ctx, OpenTelemetry.status(:error, ""))
     OpentelemetryTelemetry.end_telemetry_span(@tracer_id, meta)
+  end
+
+  def handle_controller_render_event(
+        [:phoenix, :controller, :render, :start],
+        _measurements,
+        %{template: template, view: view, format: format} = meta,
+        _handler_configuration
+      ) do
+    view_name = module_name(view)
+    span_name = "#{view_name}##{template}.#{format}"
+
+    OpentelemetryTelemetry.start_telemetry_span(
+      @tracer_id,
+      span_name,
+      meta,
+      %{kind: :server}
+    )
+  end
+
+  def handle_controller_render_event(
+        [:phoenix, :controller, :render, :stop],
+        _measurements,
+        meta,
+        _handler_configuration
+      ) do
+    OpentelemetryTelemetry.end_telemetry_span(@tracer_id, meta)
+  end
+
+  def handle_controller_render_event(
+        [:phoenix, :controller, :render, :exception],
+        _,
+        %{kind: kind, reason: reason, stacktrace: stacktrace} = meta,
+        _
+      ) do
+    ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, meta)
+
+    exception = Exception.normalize(kind, reason, stacktrace)
+
+    OpenTelemetry.Span.record_exception(ctx, exception, stacktrace, [])
+    OpenTelemetry.Span.set_status(ctx, OpenTelemetry.status(:error, ""))
+    OpentelemetryTelemetry.end_telemetry_span(@tracer_id, meta)
+  end
+
+  defp module_name(module) when is_atom(module) do
+    module
+    |> inspect()
+    |> String.trim_leading("Elixir.")
   end
 end

--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -16,6 +16,11 @@ defmodule OpentelemetryPhoenix do
                       type: :boolean,
                       default: true,
                       doc: "Whether LiveView traces will be instrumented."
+                    ],
+                    controller: [
+                      type: :boolean,
+                      default: true,
+                      doc: "Whether controller render traces will be instrumented."
                     ]
                   )
 
@@ -62,7 +67,7 @@ defmodule OpentelemetryPhoenix do
   @tracer_id __MODULE__
 
   @typedoc "Setup options"
-  @type opts :: [endpoint_prefix() | adapter() | liveview()]
+  @type opts :: [endpoint_prefix() | adapter() | liveview() | controller()]
 
   @typedoc "The endpoint prefix in your endpoint. Defaults to `[:phoenix, :endpoint]`"
   @type endpoint_prefix :: {:endpoint_prefix, [atom()]}
@@ -72,6 +77,9 @@ defmodule OpentelemetryPhoenix do
 
   @typedoc "Attach LiveView handlers. Optional"
   @type liveview :: {:liveview, boolean()}
+
+  @typedoc "Attach controller render handlers. Optional"
+  @type controller :: {:controller, boolean()}
 
   @doc """
   Initializes and configures the telemetry handlers.
@@ -87,7 +95,9 @@ defmodule OpentelemetryPhoenix do
       attach_liveview_handlers()
     end
 
-    attach_controller_render_handlers()
+    if opts[:controller] do
+      attach_controller_render_handlers()
+    end
 
     :ok
   end


### PR DESCRIPTION
We're exploring adopting OpenTelemetry for our Elixir offering at AppSignal and found that controller render actions weren't being traced.

This PR adds support for tracing Phoenix controller render events, enabling instrumentation of template rendering within controller actions.

  ## Changes

  - Attach telemetry handlers for controller render start/stop/exception events
  - Implement span creation for controller renders with format: `ViewModule#template.format` (e.g., `MyAppWeb.PageView#index.html`)
  - Add optional `controller` configuration option (enabled by default, can be disabled with `controller: false`). Added in a separate commit in case we'd like to keep this out.
  - Update module documentation to mention controller render events
