### PR TITLE
chore: allow publish-mix-hex-release to create PRs

### DIFF
--- a/.github/workflows/publish-mix-hex-release.yml
+++ b/.github/workflows/publish-mix-hex-release.yml
@@ -51,7 +51,8 @@ on:
           - publish
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   config:


### PR DESCRIPTION
permissions needed so this action can hopefully create a PR with the version bump. It is possible it still won't work after this because of organization level permissions, but we can at least try and then do it manually if it doesn't work.