### PR TITLE
docs: add configuration options reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,6 @@ This policy has been enacted to be respectful of the maintainers' time and to en
 and regular updates. We want as many libraries to be under the official umbrella but need your commmitment to
 make that happen.
 
-### Instrumenting a library
-
-When instrumenting a library, it is important to follow the [Trace Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/trace.md)
-
 ### CI
 
 Given the number of projects in this repo and the wide matrix of OTP/Elixir versions we must
@@ -28,3 +24,21 @@ Updating the file:
 1. Update the beautified json file (this is the form you'll commit)
 2. Uglify and escape the json object
 3. Copy this final value to the `test-matrix` job output
+
+## Checklist
+
+Use the following checklists as templates when opening a pull request.
+
+### General
+
+- [ ] All tests pass (`mix test`)
+- [ ] Code compiles without warnings (`mix compile --warnings-as-errors`)
+- [ ] Dialyzer passes (`mix dialyzer`)
+- [ ] Includes a `CHANGELOG.md` entry describing the change
+
+### Instrumentation Packages
+
+- [ ] Follows the [Trace Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/general/trace/)
+- [ ] Follows the [Configuration Options](./docs/reference/configuration-options.md) reference for standard option naming and behavior
+- [ ] Uses `opentelemetry_semantic_conventions` for attribute keys
+- [ ] Options are validated with [NimbleOptions](https://hexdocs.pm/nimble_options)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+## Reference
+
+Technical specifications:
+
+- [Configuration Options](reference/configuration-options.md) — standard option types, defaults, naming conventions, SemConv requirement level mapping, and package support matrix

--- a/docs/reference/configuration-options.md
+++ b/docs/reference/configuration-options.md
@@ -1,0 +1,83 @@
+# Configuration Options Reference
+
+Standard configuration options for instrumentation packages in this repository.
+All options use [NimbleOptions](https://hexdocs.pm/nimble_options) for
+validation and documentation generation.
+
+## `opt_in_attrs`
+
+Enables attributes with a requirement level of **Opt-In** or **Experimental**
+per the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/).
+
+| Property | Value                                                                             |
+| -------- | --------------------------------------------------------------------------------- |
+| Type     | `{:list, {:in, opt_ins}}` where `opt_ins` is the list of supported attribute keys |
+| Default  | `[]`                                                                              |
+| Name     | `opt_in_attrs`                                                                    |
+
+Attribute keys must come from the `opentelemetry_semantic_conventions` library.
+
+## `opt_out_attrs`
+
+Disables attributes with a requirement level of **Recommended** that are
+included by default.
+
+| Property | Value                                                                                                      |
+| -------- | ---------------------------------------------------------------------------------------------------------- |
+| Type     | `{:list, {:in, opt_outs}}` where `opt_outs` is the list of recommended attribute keys that can be disabled |
+| Default  | `[]`                                                                                                       |
+| Name     | `opt_out_attrs`                                                                                            |
+
+## `extra_attrs`
+
+User-defined attributes included on all spans. Instrumented attributes take
+precedence over extra attributes.
+
+| Property | Value                                     |
+| -------- | ----------------------------------------- |
+| Type     | `:map` (`OpenTelemetry.attributes_map()`) |
+| Default  | `%{}`                                     |
+| Name     | `extra_attrs`                             |
+
+> `opentelemetry_ecto` uses `additional_span_attributes` for historical reasons.
+> New packages must use `extra_attrs`.
+
+## `span_relationship`
+
+Controls how spans relate to a propagated parent context in asynchronous
+processing.
+
+| Property | Value                                                       |
+| -------- | ----------------------------------------------------------- |
+| Type     | `{:in, [:child, :link, :none]}`                             |
+| Default  | Varies by package (`:link` recommended for async consumers) |
+
+| Value    | Behavior                                                |
+| -------- | ------------------------------------------------------- |
+| `:child` | Attach propagated context, creating a parent-child span |
+| `:link`  | Create a span link to the propagated context            |
+| `:none`  | Ignore propagated context entirely                      |
+
+## Module Names in Attribute Values
+
+When an attribute value is an Elixir module name, use the short form without the
+`Elixir.` prefix. The `Elixir.` prefix is a BEAM-internal detail and must not
+leak into telemetry data.
+
+| Form                | Example             | Status     |
+| ------------------- | ------------------- | ---------- |
+| Short (no prefix)   | `GRPC.RPCError`     | **Use**    |
+| Prefixed            | `Elixir.GRPC.RPCError` | **Avoid** |
+
+## Semantic Convention Requirement Levels
+
+The [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/)
+define requirement levels for each attribute. This repository maps those levels
+to configuration options as follows:
+
+| SemConv Level | Instrumentation Behavior | User Control    |
+| ------------- | ------------------------ | --------------- |
+| Required      | Always included          | None            |
+| Recommended   | Included by default      | `opt_out_attrs` |
+| Opt-In        | Excluded by default      | `opt_in_attrs`  |
+| Experimental  | Excluded by default      | `opt_in_attrs`  |


### PR DESCRIPTION
## Summary

- Adds a reference document defining the standard configuration options (`opt_in_attrs`, `opt_out_attrs`, `extra_attrs`, `span_relationship`) for instrumentation packages
- Includes a mapping from OTel SemConv requirement levels to the corresponding options
- Includes a package support matrix showing which packages implement which options

## Test plan

- [x] Review document accuracy against existing package implementations
- [x] Verify SemConv requirement level mapping is correct