### PR TITLE
feat(bandit): record exception events for throws and abnormal exits too

### DIFF
--- a/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
+++ b/instrumentation/opentelemetry_bandit/lib/opentelemetry_bandit.ex
@@ -476,7 +476,7 @@ defmodule OpentelemetryBandit do
   def handle_request_exception(meta, config) do
     Tracer.set_status(OpenTelemetry.status(:error, ""))
 
-    Tracer.record_exception(meta.exception, meta.stacktrace)
+    record_exception(meta)
 
     # bandit does not set this on the meta but extracts this after the exception
     # telemetry is emitted
@@ -491,6 +491,15 @@ defmodule OpentelemetryBandit do
 
     Tracer.end_span()
     OpenTelemetry.Ctx.clear()
+  end
+
+  defp record_exception(%{exception: exception, stacktrace: stacktrace})
+       when is_exception(exception) do
+    Tracer.record_exception(exception, stacktrace)
+  end
+
+  defp record_exception(%{kind: kind, exception: reason, stacktrace: stacktrace}) do
+    :otel_span.record_exception(:otel_tracer.current_span_ctx(), kind, reason, stacktrace, [])
   end
 
   defp error_type(%struct_name{} = reason) when is_exception(reason) do

--- a/instrumentation/opentelemetry_bandit/test/bandit/opentelemetry_bandit_test.exs
+++ b/instrumentation/opentelemetry_bandit/test/bandit/opentelemetry_bandit_test.exs
@@ -452,7 +452,20 @@ defmodule OpentelemetryBanditTest do
         assert Map.get(:otel_attributes.map(span_attributes), attribute) == expected_value
       end
 
-      assert [] = :otel_events.list(events)
+      [
+        event(
+          name: :exception,
+          attributes: event_attributes
+        )
+      ] = :otel_events.list(events)
+
+      exception_type_attribute = ExceptionAttributes.exception_type()
+      exception_stacktrace_attribute = ExceptionAttributes.exception_stacktrace()
+
+      assert %{
+               ^exception_type_attribute => "throw:<<\"something\">>",
+               ^exception_stacktrace_attribute => _
+             } = :otel_attributes.map(event_attributes)
     end
 
     test "with exit" do
@@ -485,7 +498,20 @@ defmodule OpentelemetryBanditTest do
         assert Map.get(:otel_attributes.map(span_attributes), attribute) == expected_value
       end
 
-      assert [] = :otel_events.list(events)
+      [
+        event(
+          name: :exception,
+          attributes: event_attributes
+        )
+      ] = :otel_events.list(events)
+
+      exception_type_attribute = ExceptionAttributes.exception_type()
+      exception_stacktrace_attribute = ExceptionAttributes.exception_stacktrace()
+
+      assert %{
+               ^exception_type_attribute => "exit:abnormal_reason",
+               ^exception_stacktrace_attribute => _
+             } = :otel_attributes.map(event_attributes)
     end
 
     test "with halted request" do


### PR DESCRIPTION
Hi,

Following up on https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/467.

That one originally fixed `opentelemetry_bandit` to not crash when a throw/exit was emitted by `bandit`, and properly register the span with the correct error status.

BUT we never actually also recorded the OTel exception event for the case `bandit` emits a throw or a exit telemetry exception event.

This PR tries to improve that.

Thanks.