### PR TITLE
docs: add reference guide for recording exceptions on spans

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,15 @@
 # Documentation
 
+## How-to guides
+
+Task-oriented guides:
+
+- [Record Exceptions](how-to/record-exceptions.md): recording exception events, span status, and `error.type` from Telemetry handlers and non-Telemetry code paths
+
 ## Reference
 
 Technical specifications:
 
-- [Configuration Options](reference/configuration-options.md) — standard option types, defaults, naming conventions, SemConv requirement level mapping, and package support matrix
-- [Custom Span Attributes](reference/custom-span-attributes.md) — how to define package-specific span attributes using a `[Component]Attributes` module
+- [Configuration Options](reference/configuration-options.md): standard option types, defaults, naming conventions, SemConv requirement level mapping, and package support matrix
+- [Custom Span Attributes](reference/custom-span-attributes.md): how to define package-specific span attributes using a `[Component]Attributes` module
+- [Recording Exceptions](reference/recording-exceptions.md): exception event fields, span status description strings, `error.type` values, and `erlang.exception.kind`

--- a/docs/how-to/record-exceptions.md
+++ b/docs/how-to/record-exceptions.md
@@ -1,0 +1,96 @@
+# How to record exceptions on spans
+
+This guide covers recording failures on spans in instrumentation packages.
+For the API specifications, see [Recording Exceptions](../reference/recording-exceptions.md).
+
+## Handling a `:telemetry` `[:*, :exception]` event
+
+You have `%{kind: kind, reason: reason, stacktrace: stacktrace}`.
+
+**When `reason` is likely an Elixir exception struct:**
+
+```elixir
+exception = Exception.normalize(kind, reason, stacktrace)
+OpenTelemetry.Span.record_exception(ctx, exception, stacktrace, [])
+OpenTelemetry.Span.set_status(ctx, OpenTelemetry.status(:error, Exception.format_banner(kind, reason, stacktrace)))
+```
+
+When the exception event already carries sufficient detail, an empty status
+description is also acceptable (used in `opentelemetry_phoenix`):
+
+```elixir
+OpenTelemetry.Span.set_status(ctx, OpenTelemetry.status(:error, ""))
+```
+
+**When `reason` may be any term:**
+
+```elixir
+:otel_span.record_exception(ctx, kind, reason, stacktrace, [])
+OpenTelemetry.Span.set_status(ctx, OpenTelemetry.status(:error, Exception.format_banner(kind, reason, stacktrace)))
+```
+
+Always end the span in the usual way for your bridge
+(`OpentelemetryTelemetry.end_telemetry_span/2`, etc.).
+
+## Handling a non-Telemetry failure
+
+When you hold the error directly from a `{:error, reason}` return or a
+`rescue`/`catch` block, define a small helper:
+
+```elixir
+defp format_error(%{__exception__: true} = exception), do: Exception.message(exception)
+defp format_error(reason), do: inspect(reason)
+```
+
+Then record and set status:
+
+```elixir
+OpenTelemetry.Span.record_exception(ctx, exception, stacktrace, [])
+OpenTelemetry.Span.set_status(span, OpenTelemetry.status(:error, format_error(reason)))
+```
+
+## Setting `error.type`
+
+Set `error.type` on the span when the operation failed; omit it on success.
+Choose a value that stays low-cardinality:
+
+```elixir
+# HTTP status
+OpenTelemetry.Span.set_attribute(ctx, ErrorAttributes.error_type(), to_string(status_code))
+
+# Named exception
+OpenTelemetry.Span.set_attribute(ctx, ErrorAttributes.error_type(), inspect(exception.__struct__))
+
+# Unknown / opaque
+OpenTelemetry.Span.set_attribute(ctx, ErrorAttributes.error_type(), ErrorAttributes.error_type_values().other)
+```
+
+`error.type` summarises the failure class for dashboards; it does not replace
+`exception.*` fields on the event.
+
+## Recording the OTP exception class as an attribute
+
+Add `:"erlang.exception.kind"` only when backends or queries need the class as
+a structured field separate from the exception event:
+
+```elixir
+OpenTelemetry.Span.set_attribute(ctx, :"erlang.exception.kind", kind)
+```
+
+Pick one value shape per package (atom or string) and document it.
+
+## Erlang handlers
+
+Call `otel_span:record_exception/5` and set status with
+`opentelemetry:status(?OTEL_STATUS_ERROR, Message)` where `Message` is a UTF-8
+binary.
+
+## Checklist for new instrumentation
+
+1. Add an **exception event** via `OpenTelemetry.Span.record_exception/4`
+   (exception struct) or `:otel_span.record_exception/5` (raw kind/reason).
+2. Set **span status** to `OpenTelemetry.status(:error, description)` with a
+   concise description.
+3. When SemConv applies, set **`error.type`** with a low-cardinality value.
+4. Optionally set **`erlang.exception.kind`** if consumers need the OTP class
+   as a separate attribute.

--- a/docs/reference/recording-exceptions.md
+++ b/docs/reference/recording-exceptions.md
@@ -1,0 +1,97 @@
+# Recording exceptions and errors
+
+Specification for recording failures on spans in **opentelemetry-erlang-contrib**
+instrumentations.
+
+See [How to record exceptions](../how-to/record-exceptions.md) for usage guidance.
+
+## Mechanisms
+
+| Mechanism | Role |
+| --------- | ---- |
+| **Exception event** (`exception` / `:exception`) | Captures the failure for the trace: `exception.type`, optional `exception.message`, `exception.stacktrace`. |
+| **Span status** (`OpenTelemetry.status/2`) | Marks the span outcome: `:error` with a short description, or `:ok` / unset. |
+| **`error.type` span attribute** | Stable SemConv attribute for error classification; low-cardinality. Key: `OpenTelemetry.SemConv.ErrorAttributes.error_type/0`. |
+| **`erlang.exception.kind`** | Optional contrib-local attribute for the OTP exception class. Not part of stable SemConv. |
+
+## `Span.record_exception`
+
+### Elixir: `OpenTelemetry.Span.record_exception/4`
+
+```
+OpenTelemetry.Span.record_exception(span_ctx, exception, stacktrace \\ nil, attributes \\ [])
+```
+
+Requires `exception` to be a struct with `__exception__: true`. Returns `false`
+and adds no event otherwise.
+
+Produces an `exception` event with:
+
+| Field | Value |
+| ----- | ----- |
+| `exception.type` | `to_string(exception.__struct__)` |
+| `exception.message` | `Exception.message(exception)` |
+| `exception.stacktrace` | `Exception.format_stacktrace(stacktrace)` |
+
+### Erlang: `:otel_span.record_exception/5` and `/6`
+
+```
+:otel_span.record_exception(Ctx, Class, Reason, Stacktrace, Attributes)
+:otel_span.record_exception(Ctx, Class, Reason, Stacktrace, Message, Attributes)
+```
+
+Accepts any `Reason` term (atoms, tuples, bare terms). `Class` is the OTP class:
+`error`, `exit`, or `throw`.
+
+Produces an `exception` event with:
+
+| Field | Value |
+| ----- | ----- |
+| `exception.type` | Encoded `Class:Reason` string (limited print depth/length) |
+| `exception.stacktrace` | Formatted stacktrace |
+| `exception.message` | `/6` only; caller-supplied binary |
+
+## `Exception.normalize/3`
+
+```
+Exception.normalize(kind, reason, stacktrace) :: Exception.t() | term()
+```
+
+Maps OTP `kind`/`reason` pairs to an Elixir exception struct where possible.
+Result is suitable for `Exception.message/1` and
+`OpenTelemetry.Span.record_exception/4` when the return value is an exception
+struct.
+
+## Span status description strings
+
+| Source | Expression |
+| ------ | ---------- |
+| Telemetry triple | `Exception.format_banner(kind, reason, stacktrace)` |
+| Exception struct | `Exception.message(exception)` |
+| Opaque reason | `inspect(reason)` |
+| Domain-specific | HTTP status string, gRPC message, etc. |
+
+## `ErrorAttributes.error_type/0` (`error.type`)
+
+`OpenTelemetry.SemConv.ErrorAttributes.error_type/0` returns `:"error.type"`.
+
+| Situation | Example values |
+| --------- | -------------- |
+| HTTP-like status | `to_string(404)`, `to_string(500)` |
+| Named exception module | `inspect(MyApp.SomeError)`, `to_string(GRPC.RPCError)` |
+| DB / driver codes | Postgres/MySQL/TDS numeric codes |
+| Opaque / unknown | `ErrorAttributes.error_type_values().other` (`:_OTHER`) |
+| Transport / errno-style | `inspect(:econnrefused)` |
+
+Set on the span when the operation failed; omit on success.
+
+## `erlang.exception.kind`
+
+Key: `:"erlang.exception.kind"`
+
+Values: `error`, `exit`, or `throw`. Use atoms or short strings; pick one
+shape per package and document it.
+
+Not required when using `:otel_span.record_exception/5`: the OTP class is
+already encoded into `exception.type` on the event. Use this attribute only
+when consumers need the class as a structured, low-cardinality field.


### PR DESCRIPTION
## Summary

Adds `docs/reference/recording-exceptions.md`, a contributor-facing guide for how instrumentations should record failures: exception events (`record_exception`), span status (`Exception.format_banner` / `format_error` patterns), SemConv `error.type` via `OpenTelemetry.SemConv.ErrorAttributes`, and optional `erlang.exception.kind`.

Also links the new page from `docs/README.md`.

## Context

Supports consistent error/exception handling across contrib packages (Telemetry `:exception` handlers, Elixir vs `:otel_span` APIs, `Exception.normalize/3`).