### PR TITLE
refactor(opentelemetry_redix): align with Redis database SemConv

### DIFF
--- a/instrumentation/opentelemetry_redix/lib/opentelemetry_redix.ex
+++ b/instrumentation/opentelemetry_redix/lib/opentelemetry_redix.ex
@@ -13,55 +13,151 @@ defmodule OpentelemetryRedix do
         # ...
       end
 
+  ## Options
+
+  * `:db_namespace` - The Redis database index (e.g., `"0"`). Maps to the
+    `db.namespace` semantic convention attribute. Omitted if not provided.
+  * `:opt_in_attrs` - List of opt-in attributes to enable. Defaults to `[]`.
+  * `:opt_out_attrs` - List of recommended attributes to disable. Defaults to `[]`.
+  * `:extra_attrs` - User-defined attributes included on all spans. Instrumented
+    attributes take precedence. Defaults to `%{}`.
   """
 
-  alias OpenTelemetry.SemanticConventions.Trace
+  alias OpenTelemetry.SemConv.ErrorAttributes
+  alias OpenTelemetry.SemConv.Incubating.DBAttributes
+  alias OpenTelemetry.SemConv.ServerAttributes
   alias OpentelemetryRedix.Command
   alias OpentelemetryRedix.ConnectionTracker
+  alias OpentelemetryRedix.RedixAttributes
 
-  require Trace
   require OpenTelemetry.Tracer
 
+  @default_redis_port 6379
+
+  opt_ins = [
+    RedixAttributes.redix_connection_name()
+  ]
+
+  opt_outs = [
+    DBAttributes.db_query_text()
+  ]
+
+  @options_schema NimbleOptions.new!(
+                    db_namespace: [
+                      type: :string,
+                      required: false,
+                      doc: """
+                      The Redis database index (e.g., `"0"`). Maps to the `db.namespace`
+                      semantic convention attribute. Omitted if not provided.
+                      """
+                    ],
+                    opt_in_attrs: [
+                      type: {:list, {:in, opt_ins}},
+                      default: [],
+                      type_spec: quote(do: opt_in_attrs()),
+                      doc: """
+                      List of opt-in attributes to enable.
+
+                      Use the semantic conventions library to ensure compatibility.
+
+                      Opt-In Attributes:
+                      #{Enum.map_join(opt_ins, "\n\n", &"  * `#{inspect(&1)}`")}
+                      """
+                    ],
+                    opt_out_attrs: [
+                      type: {:list, {:in, opt_outs}},
+                      default: [],
+                      type_spec: quote(do: opt_out_attrs()),
+                      doc: """
+                      List of recommended attributes to opt out of.
+
+                      Use the semantic conventions library to ensure compatibility.
+
+                      Recommended Attributes:
+                      #{Enum.map_join(opt_outs, "\n\n", &"  * `#{inspect(&1)}`")}
+                      """
+                    ],
+                    extra_attrs: [
+                      type: :map,
+                      type_spec: quote(do: OpenTelemetry.attributes_map()),
+                      default: %{},
+                      doc: """
+                      User-defined attributes included on all spans. Instrumented
+                      attributes take precedence over anything supplied here.
+                      """
+                    ]
+                  )
+
+  @typedoc "Use semantic conventions library to ensure compatibility, e.g. `RedixAttributes.redix_connection_name()`"
+  @type opt_in_attr() :: unquote(RedixAttributes.redix_connection_name())
+
+  @type opt_in_attrs() :: [opt_in_attr()]
+
+  @typedoc "Use semantic conventions library to ensure compatibility, e.g. `DBAttributes.db_query_text()`"
+  @type opt_out_attr() :: unquote(DBAttributes.db_query_text())
+
+  @type opt_out_attrs() :: [opt_out_attr()]
+
   @typedoc "Setup options"
-  @type opts :: []
+  @type opts :: [unquote(NimbleOptions.option_typespec(@options_schema))]
 
   @doc """
   Initializes and configures the telemetry handlers.
+
+  Supported options:\n#{NimbleOptions.docs(@options_schema)}
   """
   @spec setup(opts()) :: :ok
-  def setup(_opts \\ []) do
+  def setup(opts \\ []) do
+    config =
+      opts
+      |> NimbleOptions.validate!(@options_schema)
+      |> Enum.into(%{})
+
     :telemetry.attach(
       {__MODULE__, :pipeline_stop},
       [:redix, :pipeline, :stop],
       &__MODULE__.handle_pipeline_stop/4,
-      :no_config
+      config
     )
   end
 
   @doc false
-  def handle_pipeline_stop(_event, measurements, meta, _config) do
+  def handle_pipeline_stop(_event, measurements, meta, config) do
     duration = measurements.duration
     end_time = :opentelemetry.timestamp()
     start_time = end_time - duration
 
-    operation =
+    {span_name, operation, batch_size} =
       case meta.commands do
-        [[operation | _args]] -> operation
-        _pipeline -> "pipeline"
-      end
+        [[op | _args]] ->
+          name = to_string(op)
+          {name, name, nil}
 
-    statement = Enum.map_join(meta.commands, "\n", &Command.sanitize/1)
+        commands ->
+          ops = Enum.map(commands, fn [op | _] -> to_string(op) end)
+
+          name =
+            case Enum.uniq(ops) do
+              [cmd] -> "PIPELINE " <> cmd
+              _ -> "PIPELINE"
+            end
+
+          {name, name, length(commands)}
+      end
 
     connection = ConnectionTracker.get_connection(meta.connection)
 
     attributes =
       %{
-        Trace.db_system() => "redis",
-        Trace.db_operation() => operation,
-        Trace.db_statement() => statement
+        :"db.system.name" => "redis",
+        DBAttributes.db_operation_name() => operation
       }
-      |> Map.merge(net_attributes(connection))
-      |> Map.merge(redix_attributes(meta))
+      |> maybe_put_query_text(meta.commands, config)
+      |> maybe_put(DBAttributes.db_namespace(), config[:db_namespace])
+      |> maybe_put(DBAttributes.db_operation_batch_size(), batch_size)
+      |> Map.merge(server_attributes(connection))
+      |> maybe_put_opt_in_attrs(connection, config)
+      |> Map.merge(config.extra_attrs, fn _k, instrumented, _extra -> instrumented end)
 
     parent_context =
       case OpentelemetryProcessPropagator.fetch_ctx(self()) do
@@ -80,14 +176,19 @@ defmodule OpentelemetryRedix do
       end
 
     s =
-      OpenTelemetry.Tracer.start_span(operation, %{
+      OpenTelemetry.Tracer.start_span(span_name, %{
         start_time: start_time,
         kind: :client,
         attributes: attributes
       })
 
     if meta[:kind] == :error do
+      if is_exception(meta.reason) do
+        OpenTelemetry.Span.record_exception(s, meta.reason, nil, [])
+      end
+
       OpenTelemetry.Span.set_status(s, OpenTelemetry.status(:error, format_error(meta.reason)))
+      OpenTelemetry.Span.set_attributes(s, error_attributes(meta.reason))
     end
 
     OpenTelemetry.Span.end_span(s)
@@ -97,16 +198,67 @@ defmodule OpentelemetryRedix do
     end
   end
 
-  defp net_attributes(%{address: address}) when is_binary(address) do
-    [host, port] = address |> String.split(":")
-    %{Trace.net_peer_name() => host, Trace.net_peer_port() => port}
+  defp maybe_put_query_text(attrs, commands, %{opt_out_attrs: opt_outs}) do
+    if DBAttributes.db_query_text() in opt_outs do
+      attrs
+    else
+      Map.put(
+        attrs,
+        DBAttributes.db_query_text(),
+        Enum.map_join(commands, "\n", &Command.sanitize/1)
+      )
+    end
   end
 
-  defp net_attributes(_), do: %{}
+  defp maybe_put_opt_in_attrs(attrs, connection, %{opt_in_attrs: opt_ins}) do
+    if RedixAttributes.redix_connection_name() in opt_ins do
+      Map.merge(attrs, redix_attributes(connection))
+    else
+      attrs
+    end
+  end
+
+  defp server_attributes(%{address: address}) when is_binary(address) do
+    case String.split(address, ":") do
+      [host, port_str] ->
+        port = String.to_integer(port_str)
+        attrs = %{ServerAttributes.server_address() => host}
+
+        if port != @default_redis_port do
+          Map.put(attrs, ServerAttributes.server_port(), port)
+        else
+          attrs
+        end
+
+      [host] ->
+        %{ServerAttributes.server_address() => host}
+    end
+  end
+
+  defp server_attributes(_), do: %{}
 
   defp redix_attributes(%{connection_name: nil}), do: %{}
-  defp redix_attributes(%{connection_name: name}), do: %{"db.redix.connection_name": name}
+
+  defp redix_attributes(%{connection_name: name}),
+    do: %{RedixAttributes.redix_connection_name() => name}
+
   defp redix_attributes(_), do: %{}
+
+  defp error_attributes(%{__exception__: true, message: message}) when is_binary(message) do
+    status_code = message |> String.split(" ", parts: 2) |> List.first()
+
+    %{
+      RedixAttributes.redix_response_status_code() => status_code,
+      ErrorAttributes.error_type() => status_code
+    }
+  end
+
+  defp error_attributes(reason) do
+    %{ErrorAttributes.error_type() => inspect(reason)}
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp format_error(%{__exception__: true} = exception), do: Exception.message(exception)
   defp format_error(reason), do: inspect(reason)

--- a/instrumentation/opentelemetry_redix/lib/opentelemetry_redix/redix_attributes.ex
+++ b/instrumentation/opentelemetry_redix/lib/opentelemetry_redix/redix_attributes.ex
@@ -1,0 +1,19 @@
+defmodule OpentelemetryRedix.RedixAttributes do
+  @moduledoc """
+  OpenTelemetry span attributes specific to the Redix instrumentation.
+
+  These attributes are not part of the OpenTelemetry Semantic Conventions.
+  """
+
+  @doc """
+  The Redis simple error prefix returned when an operation fails (e.g. `ERR`, `WRONGTYPE`).
+  """
+  @spec redix_response_status_code() :: :"redix.response.status_code"
+  def redix_response_status_code, do: :"redix.response.status_code"
+
+  @doc """
+  The name of the Redix connection.
+  """
+  @spec redix_connection_name() :: :"redix.connection.name"
+  def redix_connection_name, do: :"redix.connection.name"
+end

--- a/instrumentation/opentelemetry_redix/mix.exs
+++ b/instrumentation/opentelemetry_redix/mix.exs
@@ -58,6 +58,7 @@ defmodule OpentelemetryRedix.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.40", only: [:dev], runtime: false},
       {:opentelemetry, "~> 1.5", only: [:dev, :test]},
+      {:nimble_options, "~> 1.0"},
       {:opentelemetry_api, "~> 1.4"},
       {:opentelemetry_process_propagator, "~> 0.3"},
       {:opentelemetry_semantic_conventions, "~> 1.27"},

--- a/instrumentation/opentelemetry_redix/mix.lock
+++ b/instrumentation/opentelemetry_redix/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "acceptor_pool": {:hex, :acceptor_pool, "1.0.1", "d88c2e8a0be9216cf513fbcd3e5a4beb36bee3ff4168e85d6152c6f899359cdb", [], [], "hexpm", "f172f3d74513e8edd445c257d596fc84dbdd56d2c6fa287434269648ae5a421e"},
+  "acceptor_pool": {:hex, :acceptor_pool, "1.0.1", "d88c2e8a0be9216cf513fbcd3e5a4beb36bee3ff4168e85d6152c6f899359cdb", [:rebar3], [], "hexpm", "f172f3d74513e8edd445c257d596fc84dbdd56d2c6fa287434269648ae5a421e"},
   "chatterbox": {:hex, :ts_chatterbox, "0.15.1", "5cac4d15dd7ad61fc3c4415ce4826fc563d4643dee897a558ec4ea0b1c835c9c", [:rebar3], [{:hpack, "~> 0.3.0", [hex: :hpack_erl, repo: "hexpm", optional: false]}], "hexpm", "4f75b91451338bc0da5f52f3480fa6ef6e3a2aeecfc33686d6b3d0a0948f31aa"},
   "ctx": {:hex, :ctx, "0.6.0", "8ff88b70e6400c4df90142e7f130625b82086077a45364a78d208ed3ed53c7fe", [:rebar3], [], "hexpm", "a14ed2d1b67723dbebbe423b28d7615eb0bdcba6ff28f2d1f1b0a7e1d4aa5fc2"},
   "dialyxir": {:hex, :dialyxir, "1.4.7", "dda948fcee52962e4b6c5b4b16b2d8fa7d50d8645bbae8b8685c3f9ecb7f5f4d", [:mix], [{:erlex, ">= 0.2.8", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b34527202e6eb8cee198efec110996c25c5898f43a4094df157f8d28f27d9efe"},

--- a/instrumentation/opentelemetry_redix/test/opentelemetry_redix_test.exs
+++ b/instrumentation/opentelemetry_redix/test/opentelemetry_redix_test.exs
@@ -3,6 +3,10 @@ defmodule OpentelemetryRedixTest do
 
   doctest OpentelemetryRedix
 
+  alias OpenTelemetry.SemConv.Incubating.DBAttributes
+  alias OpenTelemetry.SemConv.ServerAttributes
+  alias OpentelemetryRedix.RedixAttributes
+
   require OpenTelemetry.Tracer
   require OpenTelemetry.Span
   require Record
@@ -21,6 +25,7 @@ defmodule OpentelemetryRedixTest do
     OpenTelemetry.Tracer.start_span("test")
 
     on_exit(fn ->
+      :telemetry.detach({OpentelemetryRedix, :pipeline_stop})
       OpenTelemetry.Tracer.end_span()
     end)
   end
@@ -40,15 +45,14 @@ defmodule OpentelemetryRedixTest do
                     )}
 
     assert %{
-             "db.operation": "SET",
-             "db.statement": "SET foo ?",
-             "db.system": "redis",
-             "net.peer.name": "localhost",
-             "net.peer.port": "6379"
-           } = :otel_attributes.map(attributes)
+             DBAttributes.db_operation_name() => "SET",
+             DBAttributes.db_query_text() => "SET foo ?",
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost"
+           } == :otel_attributes.map(attributes)
   end
 
-  test "records span on pipelines" do
+  test "records span on mixed-command pipelines" do
     OpentelemetryRedix.setup()
 
     conn = start_supervised!({Redix, []})
@@ -63,17 +67,176 @@ defmodule OpentelemetryRedixTest do
 
     assert_receive {:span,
                     span(
-                      name: "pipeline",
+                      name: "PIPELINE",
                       kind: :client,
                       attributes: attributes
                     )}
 
     assert %{
-             "db.operation": "pipeline",
-             "db.statement": "DEL counter\nINCR counter\nINCR counter\nGET counter",
-             "db.system": "redis",
-             "net.peer.name": "localhost",
-             "net.peer.port": "6379"
-           } = :otel_attributes.map(attributes)
+             DBAttributes.db_operation_name() => "PIPELINE",
+             DBAttributes.db_query_text() =>
+               "DEL counter\nINCR counter\nINCR counter\nGET counter",
+             DBAttributes.db_operation_batch_size() => 4,
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost"
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "records span on same-command pipelines" do
+    OpentelemetryRedix.setup()
+
+    conn = start_supervised!({Redix, []})
+
+    {:ok, [_, _]} =
+      Redix.pipeline(conn, [
+        ["INCR", "pipeline_same_cmd_test"],
+        ["INCR", "pipeline_same_cmd_test"]
+      ])
+
+    assert_receive {:span,
+                    span(
+                      name: "PIPELINE INCR",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    assert %{
+             DBAttributes.db_operation_name() => "PIPELINE INCR",
+             DBAttributes.db_query_text() =>
+               "INCR pipeline_same_cmd_test\nINCR pipeline_same_cmd_test",
+             DBAttributes.db_operation_batch_size() => 2,
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost"
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "records db.namespace when configured" do
+    OpentelemetryRedix.setup(db_namespace: "1")
+
+    conn = start_supervised!({Redix, []})
+
+    {:ok, "OK"} = Redix.command(conn, ["SET", "foo", "bar"])
+
+    assert_receive {:span,
+                    span(
+                      name: "SET",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    assert %{
+             DBAttributes.db_operation_name() => "SET",
+             DBAttributes.db_query_text() => "SET foo ?",
+             DBAttributes.db_namespace() => "1",
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost"
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "omits db.namespace when not configured" do
+    OpentelemetryRedix.setup()
+
+    conn = start_supervised!({Redix, []})
+
+    {:ok, "OK"} = Redix.command(conn, ["SET", "foo", "bar"])
+
+    assert_receive {:span,
+                    span(
+                      name: "SET",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    assert %{
+             DBAttributes.db_operation_name() => "SET",
+             DBAttributes.db_query_text() => "SET foo ?",
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost"
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "omits db.query.text when opted out" do
+    OpentelemetryRedix.setup(opt_out_attrs: [DBAttributes.db_query_text()])
+
+    conn = start_supervised!({Redix, []})
+
+    {:ok, "OK"} = Redix.command(conn, ["SET", "foo", "bar"])
+
+    assert_receive {:span,
+                    span(
+                      name: "SET",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    assert %{
+             DBAttributes.db_operation_name() => "SET",
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost"
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "includes redix.connection.name when opted in" do
+    OpentelemetryRedix.setup(opt_in_attrs: [RedixAttributes.redix_connection_name()])
+
+    conn = start_supervised!({Redix, [name: :my_conn]})
+
+    {:ok, "OK"} = Redix.command(conn, ["SET", "foo", "bar"])
+
+    assert_receive {:span,
+                    span(
+                      name: "SET",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    assert %{
+             DBAttributes.db_operation_name() => "SET",
+             DBAttributes.db_query_text() => "SET foo ?",
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost",
+             RedixAttributes.redix_connection_name() => :my_conn
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "merges extra_attrs onto spans" do
+    OpentelemetryRedix.setup(extra_attrs: %{:"custom.attr" => "value"})
+
+    conn = start_supervised!({Redix, []})
+
+    {:ok, "OK"} = Redix.command(conn, ["SET", "foo", "bar"])
+
+    assert_receive {:span,
+                    span(
+                      name: "SET",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    assert %{
+             DBAttributes.db_operation_name() => "SET",
+             DBAttributes.db_query_text() => "SET foo ?",
+             :"db.system.name" => "redis",
+             ServerAttributes.server_address() => "localhost",
+             :"custom.attr" => "value"
+           } == :otel_attributes.map(attributes)
+  end
+
+  test "instrumented attributes take precedence over extra_attrs" do
+    OpentelemetryRedix.setup(extra_attrs: %{DBAttributes.db_operation_name() => "OVERRIDDEN"})
+
+    conn = start_supervised!({Redix, []})
+
+    {:ok, "OK"} = Redix.command(conn, ["SET", "foo", "bar"])
+
+    assert_receive {:span,
+                    span(
+                      name: "SET",
+                      kind: :client,
+                      attributes: attributes
+                    )}
+
+    attrs = :otel_attributes.map(attributes)
+    assert attrs[DBAttributes.db_operation_name()] == "SET"
   end
 end


### PR DESCRIPTION
- Replaces deprecated `db.system`, `db.operation`, `db.statement`, `net.peer.name/port` with current SemConv: `db.system.name`, `db.operation.name`, `db.query.text`, `server.address`, `server.port`
- Omits `server.port` when it equals the Redis default (6379)
- Adds `db_namespace` option mapping to `db.namespace` attribute
- Improves pipeline span naming from `"pipeline"` to `"PIPELINE GET SET ..."`
- Adds `db.operation.batch_size` for pipeline commands
- Adds `db.response.status_code` and `error.type` on Redis errors
- Detaches telemetry handler in test teardown to prevent cross-test leakage