### PR TITLE
feat(opentelemetry_broadway): close broadway batch tracing gap

### DIFF
--- a/instrumentation/opentelemetry_broadway/README.md
+++ b/instrumentation/opentelemetry_broadway/README.md
@@ -5,6 +5,7 @@
 ![Build Status](https://github.com/open-telemetry/opentelemetry-erlang-contrib/workflows/Erlang/badge.svg)
 
 OpenTelemetry tracing for [Broadway](https://elixir-broadway.org/) pipelines with support for distributed tracing.
+The instrumentation covers both message processing and batch processing.
 
 ## Usage
 
@@ -20,18 +21,39 @@ def start(_type, _args) do
 end
 ```
 
+### Trace Coverage
+
+`opentelemetry_broadway` emits consumer spans for:
+
+- Broadway processor message handling
+- Broadway batch processor `handle_batch/4` execution
+
+Message spans may include:
+
+- `messaging.message.body.size`
+- `messaging.message.id`
+
+Batch spans include:
+
+- `messaging.batch.message_count`
+- `broadway.messaging.batch.successful_count`
+- `broadway.messaging.batch.failed_count`
+
 ### With Trace Propagation
 
 For Broadway pipelines that need distributed tracing with linked spans across services (extracts context from message headers and creates trace links):
 
 ```elixir
 def start(_type, _args) do
-  # Enable trace propagation from message headers
-  OpentelemetryBroadway.setup(propagation: true)
+  OpentelemetryBroadway.setup(span_relationship: :link)
 
   Supervisor.start_link(...)
 end
 ```
+
+Use `span_relationship: :child` when Broadway should continue an extracted parent context for
+single-message processor spans. Batch spans still use links when a single parent-child
+relationship would be ambiguous across multiple messages.
 
 ## Installation
 

--- a/instrumentation/opentelemetry_broadway/README.md
+++ b/instrumentation/opentelemetry_broadway/README.md
@@ -36,8 +36,8 @@ Message spans may include:
 Batch spans include:
 
 - `messaging.batch.message_count`
-- `broadway.messaging.batch.successful_count`
-- `broadway.messaging.batch.failed_count`
+- `messaging.broadway.batch.successful_count`
+- `messaging.broadway.batch.failed_count`
 
 ### With Trace Propagation
 

--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
@@ -263,8 +263,8 @@ defmodule OpentelemetryBroadway do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, metadata)
 
     Span.set_attributes(ctx, [
-      {BroadwayAttributes.broadway_messaging_batch_successful_count(), length(successful_messages)},
-      {BroadwayAttributes.broadway_messaging_batch_failed_count(), length(failed_messages)}
+      {BroadwayAttributes.messaging_broadway_batch_successful_count(), length(successful_messages)},
+      {BroadwayAttributes.messaging_broadway_batch_failed_count(), length(failed_messages)}
     ])
 
     Span.set_status(ctx, batch_status(successful_messages, failed_messages))
@@ -368,7 +368,6 @@ defmodule OpentelemetryBroadway do
     case get_propagated_ctx(message) do
       {_links, parent_ctx} when parent_ctx != :undefined ->
         Ctx.attach(parent_ctx)
-
         # When we attach the context, we don't need links - parent-child relationship is established
         []
 

--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
@@ -2,7 +2,8 @@ defmodule OpentelemetryBroadway do
   @moduledoc """
   OpenTelemetry tracing for [Broadway](https://elixir-broadway.org/) pipelines with optional trace propagation support.
 
-  It supports job start, stop, and exception events with automatic distributed tracing context extraction.
+  It supports message processor start, stop, and exception events, plus batch processor start
+  and stop events with automatic distributed tracing context extraction.
 
   ## Usage
 
@@ -67,6 +68,8 @@ defmodule OpentelemetryBroadway do
   alias OpenTelemetry.SemConv.Incubating.MessagingAttributes
 
   @tracer_id __MODULE__
+  @broadway_messaging_batch_successful_count :"broadway.messaging.batch.successful_count"
+  @broadway_messaging_batch_failed_count :"broadway.messaging.batch.failed_count"
 
   @options_schema [
     span_relationship: [
@@ -121,26 +124,45 @@ defmodule OpentelemetryBroadway do
       |> NimbleOptions.validate!(@nimble_options_schema)
       |> Enum.into(%{})
 
-    :telemetry.attach(
-      "#{__MODULE__}.message_start",
-      [:broadway, :processor, :message, :start],
-      &__MODULE__.handle_message_start/4,
-      config
-    )
+    :ok =
+      :telemetry.attach(
+        "#{__MODULE__}.message_start",
+        [:broadway, :processor, :message, :start],
+        &__MODULE__.handle_message_start/4,
+        config
+      )
 
-    :telemetry.attach(
-      "#{__MODULE__}.message_stop",
-      [:broadway, :processor, :message, :stop],
-      &__MODULE__.handle_message_stop/4,
-      config
-    )
+    :ok =
+      :telemetry.attach(
+        "#{__MODULE__}.message_stop",
+        [:broadway, :processor, :message, :stop],
+        &__MODULE__.handle_message_stop/4,
+        config
+      )
 
-    :telemetry.attach(
-      "#{__MODULE__}.message_exception",
-      [:broadway, :processor, :message, :exception],
-      &__MODULE__.handle_message_exception/4,
-      config
-    )
+    :ok =
+      :telemetry.attach(
+        "#{__MODULE__}.message_exception",
+        [:broadway, :processor, :message, :exception],
+        &__MODULE__.handle_message_exception/4,
+        config
+      )
+
+    :ok =
+      :telemetry.attach(
+        "#{__MODULE__}.batch_processor_start",
+        [:broadway, :batch_processor, :start],
+        &__MODULE__.handle_batch_start/4,
+        config
+      )
+
+    :ok =
+      :telemetry.attach(
+        "#{__MODULE__}.batch_processor_stop",
+        [:broadway, :batch_processor, :stop],
+        &__MODULE__.handle_batch_stop/4,
+        config
+      )
 
     :ok
   end
@@ -203,17 +225,97 @@ defmodule OpentelemetryBroadway do
     OpentelemetryTelemetry.end_telemetry_span(@tracer_id, metadata)
   end
 
+  @doc false
+  def handle_batch_start(
+        _event,
+        _measurements,
+        %{
+          topology_name: topology_name,
+          name: name,
+          messages: messages,
+          batch_info: batch_info
+        } = metadata,
+        config
+      ) do
+    span_name = "#{inspect(topology_name)}/#{Atom.to_string(batch_info.batcher)} batch"
+    client_id = inspect(name)
+
+    span_opts = %{
+      kind: :consumer,
+      attributes: build_batch_attributes(messages, client_id)
+    }
+
+    links = collect_batch_links(messages, config.span_relationship)
+    span_opts = put_links(span_opts, links)
+
+    OpentelemetryTelemetry.start_telemetry_span(@tracer_id, span_name, metadata, span_opts)
+  end
+
+  @doc false
+  def handle_batch_stop(
+        _event,
+        _measurements,
+        %{
+          successful_messages: successful_messages,
+          failed_messages: failed_messages
+        } = metadata,
+        _config
+      ) do
+    ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, metadata)
+
+    Span.set_attributes(ctx, [
+      {@broadway_messaging_batch_successful_count, length(successful_messages)},
+      {@broadway_messaging_batch_failed_count, length(failed_messages)}
+    ])
+
+    Span.set_status(ctx, batch_status(successful_messages, failed_messages))
+    OpentelemetryTelemetry.end_telemetry_span(@tracer_id, metadata)
+  end
+
   defp otel_status(%{status: :ok}), do: OpenTelemetry.status(:ok)
   defp otel_status(%{status: {:failed, err}}), do: OpenTelemetry.status(:error, format_error(err))
   defp otel_status(_), do: OpenTelemetry.status(:unset)
 
-  defp build_message_attributes(%Broadway.Message{}, client_id) do
+  defp build_message_attributes(%Broadway.Message{data: data, metadata: metadata}, client_id) do
     %{
       MessagingAttributes.messaging_system() => :broadway,
       MessagingAttributes.messaging_operation_type() => :process,
       MessagingAttributes.messaging_client_id() => client_id
     }
+    |> maybe_put_body_size(data)
+    |> maybe_put_message_id(metadata)
   end
+
+  defp build_batch_attributes(messages, client_id) do
+    %{
+      MessagingAttributes.messaging_system() => :broadway,
+      MessagingAttributes.messaging_operation_type() => :process,
+      MessagingAttributes.messaging_client_id() => client_id,
+      MessagingAttributes.messaging_batch_message_count() => length(messages)
+    }
+  end
+
+  defp batch_status(_successful_messages, []), do: OpenTelemetry.status(:ok)
+
+  defp batch_status(_successful_messages, failed_messages) do
+    OpenTelemetry.status(:error, "#{length(failed_messages)} messages failed")
+  end
+
+  defp maybe_put_body_size(attrs, data) when is_binary(data) do
+    Map.put(attrs, MessagingAttributes.messaging_message_body_size(), byte_size(data))
+  end
+
+  defp maybe_put_body_size(attrs, _data), do: attrs
+
+  defp maybe_put_message_id(attrs, %{message_id: message_id}) when is_binary(message_id) do
+    Map.put(attrs, MessagingAttributes.messaging_message_id(), message_id)
+  end
+
+  defp maybe_put_message_id(attrs, %{delivery_tag: delivery_tag}) when is_integer(delivery_tag) do
+    Map.put(attrs, MessagingAttributes.messaging_message_id(), Integer.to_string(delivery_tag))
+  end
+
+  defp maybe_put_message_id(attrs, _metadata), do: attrs
 
   defp format_error(err) when is_binary(err), do: err
   defp format_error(err), do: inspect(err)
@@ -255,10 +357,19 @@ defmodule OpentelemetryBroadway do
     []
   end
 
+  defp collect_batch_links(_messages, :none), do: []
+
+  defp collect_batch_links(messages, _relationship) do
+    messages
+    |> Enum.flat_map(&link_from_propagated_ctx/1)
+    |> Enum.uniq_by(fn link -> {link.trace_id, link.span_id} end)
+  end
+
   defp extract_and_attach(message) do
     case get_propagated_ctx(message) do
       {_links, parent_ctx} when parent_ctx != :undefined ->
         Ctx.attach(parent_ctx)
+
         # When we attach the context, we don't need links - parent-child relationship is established
         []
 

--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
@@ -362,7 +362,7 @@ defmodule OpentelemetryBroadway do
   defp collect_batch_links(messages, _relationship) do
     messages
     |> Enum.flat_map(&link_from_propagated_ctx/1)
-    |> Enum.uniq_by(fn link -> {link.trace_id, link.span_id} end)
+    |> Enum.uniq_by(&{&1.trace_id, &1.span_id})
   end
 
   defp extract_and_attach(message) do

--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
@@ -66,10 +66,9 @@ defmodule OpentelemetryBroadway do
   alias OpenTelemetry.Tracer
   alias OpenTelemetry.Span
   alias OpenTelemetry.SemConv.Incubating.MessagingAttributes
+  alias OpentelemetryBroadway.BroadwayAttributes
 
   @tracer_id __MODULE__
-  @broadway_messaging_batch_successful_count :"broadway.messaging.batch.successful_count"
-  @broadway_messaging_batch_failed_count :"broadway.messaging.batch.failed_count"
 
   @options_schema [
     span_relationship: [
@@ -264,8 +263,8 @@ defmodule OpentelemetryBroadway do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, metadata)
 
     Span.set_attributes(ctx, [
-      {@broadway_messaging_batch_successful_count, length(successful_messages)},
-      {@broadway_messaging_batch_failed_count, length(failed_messages)}
+      {BroadwayAttributes.broadway_messaging_batch_successful_count(), length(successful_messages)},
+      {BroadwayAttributes.broadway_messaging_batch_failed_count(), length(failed_messages)}
     ])
 
     Span.set_status(ctx, batch_status(successful_messages, failed_messages))

--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway/broadway_attributes.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway/broadway_attributes.ex
@@ -12,10 +12,10 @@ defmodule OpentelemetryBroadway.BroadwayAttributes do
 
   Value must be of type `non_neg_integer()`.
   """
-  @spec broadway_messaging_batch_successful_count() ::
-          :"broadway.messaging.batch.successful_count"
-  def broadway_messaging_batch_successful_count do
-    :"broadway.messaging.batch.successful_count"
+  @spec messaging_broadway_batch_successful_count() ::
+          :"messaging.broadway.batch.successful_count"
+  def messaging_broadway_batch_successful_count do
+    :"messaging.broadway.batch.successful_count"
   end
 
   @doc """
@@ -25,8 +25,8 @@ defmodule OpentelemetryBroadway.BroadwayAttributes do
 
   Value must be of type `non_neg_integer()`.
   """
-  @spec broadway_messaging_batch_failed_count() :: :"broadway.messaging.batch.failed_count"
-  def broadway_messaging_batch_failed_count do
-    :"broadway.messaging.batch.failed_count"
+  @spec messaging_broadway_batch_failed_count() :: :"messaging.broadway.batch.failed_count"
+  def messaging_broadway_batch_failed_count do
+    :"messaging.broadway.batch.failed_count"
   end
 end

--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway/broadway_attributes.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway/broadway_attributes.ex
@@ -1,0 +1,32 @@
+defmodule OpentelemetryBroadway.BroadwayAttributes do
+  @moduledoc """
+  OpenTelemetry span attributes specific to the Broadway instrumentation.
+
+  These attributes are not part of the OpenTelemetry Semantic Conventions.
+  """
+
+  @doc """
+  The number of messages in the batch that completed successfully.
+
+  ### Value type
+
+  Value must be of type `non_neg_integer()`.
+  """
+  @spec broadway_messaging_batch_successful_count() ::
+          :"broadway.messaging.batch.successful_count"
+  def broadway_messaging_batch_successful_count do
+    :"broadway.messaging.batch.successful_count"
+  end
+
+  @doc """
+  The number of messages in the batch that failed.
+
+  ### Value type
+
+  Value must be of type `non_neg_integer()`.
+  """
+  @spec broadway_messaging_batch_failed_count() :: :"broadway.messaging.batch.failed_count"
+  def broadway_messaging_batch_failed_count do
+    :"broadway.messaging.batch.failed_count"
+  end
+end

--- a/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
+++ b/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
@@ -93,8 +93,8 @@ defmodule OpentelemetryBroadwayTest do
     assert attrs_map[:"messaging.system"] == :broadway
     assert attrs_map[:"messaging.operation.type"] == :process
     assert attrs_map[:"messaging.batch.message_count"] == 2
-    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_successful_count()] == 2
-    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_failed_count()] == 0
+    assert attrs_map[BroadwayAttributes.messaging_broadway_batch_successful_count()] == 2
+    assert attrs_map[BroadwayAttributes.messaging_broadway_batch_failed_count()] == 0
   end
 
   test "records batch span for a real Broadway batch" do
@@ -111,8 +111,8 @@ defmodule OpentelemetryBroadwayTest do
     assert attrs_map[:"messaging.system"] == :broadway
     assert attrs_map[:"messaging.operation.type"] == :process
     assert attrs_map[:"messaging.batch.message_count"] == 2
-    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_successful_count()] == 2
-    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_failed_count()] == 0
+    assert attrs_map[BroadwayAttributes.messaging_broadway_batch_successful_count()] == 2
+    assert attrs_map[BroadwayAttributes.messaging_broadway_batch_failed_count()] == 0
   end
 
   test "marks batch processor span as errored when failed messages are present" do
@@ -149,8 +149,8 @@ defmodule OpentelemetryBroadwayTest do
                     )}
 
     attrs_map = :otel_attributes.map(attributes)
-    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_successful_count()] == 1
-    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_failed_count()] == 1
+    assert attrs_map[BroadwayAttributes.messaging_broadway_batch_successful_count()] == 1
+    assert attrs_map[BroadwayAttributes.messaging_broadway_batch_failed_count()] == 1
   end
 
   test "collects unique propagated links for batch processor spans" do

--- a/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
+++ b/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
@@ -6,6 +6,8 @@ defmodule OpentelemetryBroadwayTest do
   require OpenTelemetry.Span
   require Record
 
+  alias OpentelemetryBroadway.BroadwayAttributes
+
   for {name, spec} <- Record.extract_all(from_lib: "opentelemetry/include/otel_span.hrl") do
     Record.defrecord(name, spec)
   end
@@ -91,8 +93,8 @@ defmodule OpentelemetryBroadwayTest do
     assert attrs_map[:"messaging.system"] == :broadway
     assert attrs_map[:"messaging.operation.type"] == :process
     assert attrs_map[:"messaging.batch.message_count"] == 2
-    assert attrs_map[:"broadway.messaging.batch.successful_count"] == 2
-    assert attrs_map[:"broadway.messaging.batch.failed_count"] == 0
+    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_successful_count()] == 2
+    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_failed_count()] == 0
   end
 
   test "records batch span for a real Broadway batch" do
@@ -109,8 +111,8 @@ defmodule OpentelemetryBroadwayTest do
     assert attrs_map[:"messaging.system"] == :broadway
     assert attrs_map[:"messaging.operation.type"] == :process
     assert attrs_map[:"messaging.batch.message_count"] == 2
-    assert attrs_map[:"broadway.messaging.batch.successful_count"] == 2
-    assert attrs_map[:"broadway.messaging.batch.failed_count"] == 0
+    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_successful_count()] == 2
+    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_failed_count()] == 0
   end
 
   test "marks batch processor span as errored when failed messages are present" do
@@ -147,8 +149,8 @@ defmodule OpentelemetryBroadwayTest do
                     )}
 
     attrs_map = :otel_attributes.map(attributes)
-    assert attrs_map[:"broadway.messaging.batch.successful_count"] == 1
-    assert attrs_map[:"broadway.messaging.batch.failed_count"] == 1
+    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_successful_count()] == 1
+    assert attrs_map[BroadwayAttributes.broadway_messaging_batch_failed_count()] == 1
   end
 
   test "collects unique propagated links for batch processor spans" do

--- a/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
+++ b/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
@@ -50,6 +50,264 @@ defmodule OpentelemetryBroadwayTest do
     attrs_map = :otel_attributes.map(attributes)
     assert attrs_map[:"messaging.system"] == :broadway
     assert attrs_map[:"messaging.operation.type"] == :process
+    assert attrs_map[:"messaging.message.body.size"] == 7
+  end
+
+  test "records span on successful batch processor event" do
+    messages = [
+      %Broadway.Message{data: "first", metadata: %{}, acknowledger: {Broadway.NoopAcknowledger, nil, nil}},
+      %Broadway.Message{data: "second", metadata: %{}, acknowledger: {Broadway.NoopAcknowledger, nil, nil}}
+    ]
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :start],
+      %{},
+      %{
+        topology_name: :test_topology,
+        name: :"test_topology.Broadway.BatchProcessor_0",
+        messages: messages,
+        batch_info: %{batcher: :default}
+      }
+    )
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :stop],
+      %{},
+      %{successful_messages: messages, failed_messages: []}
+    )
+
+    expected_status = OpenTelemetry.status(:ok)
+
+    assert_receive {:span,
+                    span(
+                      name: ":test_topology/default batch",
+                      attributes: attributes,
+                      parent_span_id: :undefined,
+                      kind: :consumer,
+                      status: ^expected_status
+                    )}
+
+    attrs_map = :otel_attributes.map(attributes)
+    assert attrs_map[:"messaging.system"] == :broadway
+    assert attrs_map[:"messaging.operation.type"] == :process
+    assert attrs_map[:"messaging.batch.message_count"] == 2
+    assert attrs_map[:"broadway.messaging.batch.successful_count"] == 2
+    assert attrs_map[:"broadway.messaging.batch.failed_count"] == 0
+  end
+
+  test "records batch span for a real Broadway batch" do
+    ref = Broadway.test_batch(TestBroadway, ["success", "success"], batch_mode: :bulk)
+
+    assert_receive {:ack, ^ref, successful, []}, 1_000
+    assert length(successful) == 2
+
+    span = assert_receive_span_named("TestBroadway/default batch")
+    attrs_map = :otel_attributes.map(span(span, :attributes))
+
+    assert span(span, :kind) == :consumer
+    assert span(span, :status) == OpenTelemetry.status(:ok)
+    assert attrs_map[:"messaging.system"] == :broadway
+    assert attrs_map[:"messaging.operation.type"] == :process
+    assert attrs_map[:"messaging.batch.message_count"] == 2
+    assert attrs_map[:"broadway.messaging.batch.successful_count"] == 2
+    assert attrs_map[:"broadway.messaging.batch.failed_count"] == 0
+  end
+
+  test "marks batch processor span as errored when failed messages are present" do
+    messages = [
+      %Broadway.Message{data: "first", metadata: %{}, acknowledger: {Broadway.NoopAcknowledger, nil, nil}},
+      %Broadway.Message{data: "second", metadata: %{}, acknowledger: {Broadway.NoopAcknowledger, nil, nil}}
+    ]
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :start],
+      %{},
+      %{
+        topology_name: :test_topology,
+        name: :"test_topology.Broadway.BatchProcessor_0",
+        messages: messages,
+        batch_info: %{batcher: :default}
+      }
+    )
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :stop],
+      %{},
+      %{successful_messages: [hd(messages)], failed_messages: [List.last(messages)]}
+    )
+
+    expected_status = OpenTelemetry.status(:error, "1 messages failed")
+
+    assert_receive {:span,
+                    span(
+                      name: ":test_topology/default batch",
+                      attributes: attributes,
+                      kind: :consumer,
+                      status: ^expected_status
+                    )}
+
+    attrs_map = :otel_attributes.map(attributes)
+    assert attrs_map[:"broadway.messaging.batch.successful_count"] == 1
+    assert attrs_map[:"broadway.messaging.batch.failed_count"] == 1
+  end
+
+  test "collects unique propagated links for batch processor spans" do
+    TestHelpers.remove_handlers()
+    :ok = OpentelemetryBroadway.setup(propagation: true)
+
+    _parent_span_ctx =
+      OpenTelemetry.Tracer.start_span("batch-upstream-service")
+      |> OpenTelemetry.Tracer.set_current_span()
+
+    trace_ctx = OpenTelemetry.Tracer.current_span_ctx()
+    trace_id = elem(trace_ctx, 1)
+    hex_trace_id = elem(trace_ctx, 2)
+    span_id = elem(trace_ctx, 3)
+    hex_span_id = elem(trace_ctx, 4)
+
+    OpenTelemetry.Tracer.end_span()
+    OpenTelemetry.Ctx.clear()
+
+    assert_receive {:span, span(name: "batch-upstream-service")}
+
+    traceparent = "00-#{hex_trace_id}-#{hex_span_id}-01"
+
+    messages = [
+      %Broadway.Message{
+        data: "first",
+        metadata: %{headers: [{"traceparent", :longstr, traceparent}]},
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      },
+      %Broadway.Message{
+        data: "second",
+        metadata: %{headers: [{"traceparent", :longstr, traceparent}]},
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      }
+    ]
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :start],
+      %{},
+      %{
+        topology_name: :test_topology,
+        name: :"test_topology.Broadway.BatchProcessor_0",
+        messages: messages,
+        batch_info: %{batcher: :default}
+      }
+    )
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :stop],
+      %{},
+      %{successful_messages: messages, failed_messages: []}
+    )
+
+    assert_receive {:span, span(name: ":test_topology/default batch", links: links)}
+
+    links_list = elem(links, 5)
+    assert length(links_list) == 1
+    [link] = links_list
+    assert elem(link, 1) == trace_id
+    assert elem(link, 2) == span_id
+  end
+
+  test "batch processor span has no links when propagation is disabled" do
+    TestHelpers.remove_handlers()
+    :ok = OpentelemetryBroadway.setup(propagation: false)
+
+    _parent_span_ctx =
+      OpenTelemetry.Tracer.start_span("batch-upstream-disabled")
+      |> OpenTelemetry.Tracer.set_current_span()
+
+    traceparent = create_rabbitmq_traceparent()
+
+    OpenTelemetry.Tracer.end_span()
+    OpenTelemetry.Ctx.clear()
+
+    assert_receive {:span, span(name: "batch-upstream-disabled")}
+
+    messages = [
+      %Broadway.Message{
+        data: "success",
+        metadata: %{headers: [{"traceparent", :longstr, traceparent}]},
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      }
+    ]
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :start],
+      %{},
+      %{
+        topology_name: :test_topology,
+        name: :"test_topology.Broadway.BatchProcessor_0",
+        messages: messages,
+        batch_info: %{batcher: :default}
+      }
+    )
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :stop],
+      %{},
+      %{successful_messages: messages, failed_messages: []}
+    )
+
+    assert_receive {:span, span(name: ":test_topology/default batch", links: links)}
+
+    links_list = elem(links, 5)
+    assert length(links_list) == 0
+  end
+
+  test "batch processor spans use links when span_relationship is child and messages have multiple parents" do
+    TestHelpers.remove_handlers()
+    :ok = OpentelemetryBroadway.setup(span_relationship: :child)
+
+    {first_trace_id, first_span_id, first_traceparent} = create_parent_traceparent("batch-parent-one")
+    {second_trace_id, second_span_id, second_traceparent} = create_parent_traceparent("batch-parent-two")
+
+    messages = [
+      %Broadway.Message{
+        data: "first",
+        metadata: %{headers: [{"traceparent", :longstr, first_traceparent}]},
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      },
+      %Broadway.Message{
+        data: "second",
+        metadata: %{headers: [{"traceparent", :longstr, second_traceparent}]},
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      }
+    ]
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :start],
+      %{},
+      %{
+        topology_name: :test_topology,
+        name: :"test_topology.Broadway.BatchProcessor_0",
+        messages: messages,
+        batch_info: %{batcher: :default}
+      }
+    )
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :stop],
+      %{},
+      %{successful_messages: messages, failed_messages: []}
+    )
+
+    assert_receive {:span, span(name: ":test_topology/default batch", trace_id: batch_trace_id, links: links)}
+
+    links_list = elem(links, 5)
+    assert length(links_list) == 2
+
+    link_pairs =
+      links_list
+      |> Enum.map(fn link -> {elem(link, 1), elem(link, 2)} end)
+      |> MapSet.new()
+
+    assert MapSet.member?(link_pairs, {first_trace_id, first_span_id})
+    assert MapSet.member?(link_pairs, {second_trace_id, second_span_id})
+    refute batch_trace_id == first_trace_id
+    refute batch_trace_id == second_trace_id
   end
 
   test "records span on message which fails" do
@@ -147,6 +405,8 @@ defmodule OpentelemetryBroadwayTest do
     attrs_map = :otel_attributes.map(attributes)
     assert attrs_map[:"messaging.system"] == :broadway
     assert attrs_map[:"messaging.operation.type"] == :process
+    assert attrs_map[:"messaging.message.body.size"] == byte_size("test message")
+    assert attrs_map[:"messaging.message.id"] == "123"
 
     links_list = elem(links, 5)
     assert length(links_list) == 1
@@ -369,6 +629,7 @@ defmodule OpentelemetryBroadwayTest do
 
     attrs_map = :otel_attributes.map(attributes)
     assert attrs_map[:"messaging.system"] == :broadway
+    assert attrs_map[:"messaging.message.id"] == "a59662d4-76c5-43f7-8a80-5f9749038741"
 
     links_list = elem(links, 5)
     assert length(links_list) == 0
@@ -638,10 +899,53 @@ defmodule OpentelemetryBroadwayTest do
   end
 
   defp create_rabbitmq_headers_with_trace_context do
+    [{"traceparent", :longstr, create_rabbitmq_traceparent()}]
+  end
+
+  defp create_rabbitmq_traceparent do
     trace_ctx = OpenTelemetry.Tracer.current_span_ctx()
     hex_trace_id = elem(trace_ctx, 2)
     hex_span_id = elem(trace_ctx, 4)
 
-    [{"traceparent", :longstr, "00-#{hex_trace_id}-#{hex_span_id}-01"}]
+    "00-#{hex_trace_id}-#{hex_span_id}-01"
+  end
+
+  defp create_parent_traceparent(name) do
+    _parent_span_ctx =
+      OpenTelemetry.Tracer.start_span(name)
+      |> OpenTelemetry.Tracer.set_current_span()
+
+    trace_ctx = OpenTelemetry.Tracer.current_span_ctx()
+    trace_id = elem(trace_ctx, 1)
+    hex_trace_id = elem(trace_ctx, 2)
+    span_id = elem(trace_ctx, 3)
+    hex_span_id = elem(trace_ctx, 4)
+
+    OpenTelemetry.Tracer.end_span()
+    OpenTelemetry.Ctx.clear()
+
+    assert_receive {:span, span(name: ^name)}
+
+    {trace_id, span_id, "00-#{hex_trace_id}-#{hex_span_id}-01"}
+  end
+
+  defp assert_receive_span_named(name, timeout \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_assert_receive_span_named(name, deadline)
+  end
+
+  defp do_assert_receive_span_named(name, deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:span, span(name: ^name) = span} ->
+        span
+
+      {:span, _other_span} ->
+        do_assert_receive_span_named(name, deadline)
+    after
+      remaining ->
+        flunk("expected span named #{inspect(name)}")
+    end
   end
 end

--- a/instrumentation/opentelemetry_broadway/test/support/test_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/test/support/test_broadway.ex
@@ -11,7 +11,10 @@ defmodule TestBroadway do
         default: []
       ],
       batchers: [
-        default: []
+        default: [
+          batch_size: 2,
+          batch_timeout: 10
+        ]
       ]
     )
   end


### PR DESCRIPTION
- Broadway tracing currently stops at message processor spans, leaving handle_batch/4 work and batch outcomes invisible in traces.
- Batch-level counters make partially failed batches easier to spot without reconstructing outcomes from individual message spans alone.
- The added coverage locks in batch tracing and propagation behavior so future changes do not silently regress it.