### PR TITLE
feat(opentelemetry_broadway): attach per-message attributes to span links

### DIFF
--- a/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
+++ b/instrumentation/opentelemetry_broadway/lib/opentelemetry_broadway.ex
@@ -383,18 +383,20 @@ defmodule OpentelemetryBroadway do
   end
 
   defp get_propagated_ctx(message) do
-    message
-    |> get_message_headers()
-    |> Enum.map(&normalize_header/1)
-    |> Enum.reject(&is_nil/1)
-    |> extract_to_ctx()
+    headers =
+      message
+      |> get_message_headers()
+      |> Enum.map(&normalize_header/1)
+      |> Enum.reject(&is_nil/1)
+
+    extract_to_ctx(headers, message)
   end
 
-  defp extract_to_ctx([]) do
+  defp extract_to_ctx([], _message) do
     {[], :undefined}
   end
 
-  defp extract_to_ctx(headers) do
+  defp extract_to_ctx(headers, message) do
     ctx =
       Ctx.new()
       |> :otel_propagator_text_map.extract_to(headers)
@@ -409,8 +411,12 @@ defmodule OpentelemetryBroadway do
 
       span_ctx ->
         # Return links first, then context (for parent-child relationships)
-        {[OpenTelemetry.link(span_ctx)], ctx}
+        {[OpenTelemetry.link(span_ctx, build_link_attributes(message))], ctx}
     end
+  end
+
+  defp build_link_attributes(%Broadway.Message{} = message) do
+    maybe_put_message_id(%{}, message.metadata)
   end
 
   # RabbitMQ: headers are in metadata.headers as a list

--- a/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
+++ b/instrumentation/opentelemetry_broadway/test/opentelemetry_broadway_test.exs
@@ -213,6 +213,62 @@ defmodule OpentelemetryBroadwayTest do
     assert elem(link, 2) == span_id
   end
 
+  test "attaches per-message identifying attributes to batch processor span links" do
+    TestHelpers.remove_handlers()
+    :ok = OpentelemetryBroadway.setup(span_relationship: :child)
+
+    {first_trace_id, first_span_id, first_traceparent} = create_parent_traceparent("batch-parent-one")
+    {second_trace_id, second_span_id, second_traceparent} = create_parent_traceparent("batch-parent-two")
+
+    messages = [
+      %Broadway.Message{
+        data: "first",
+        metadata: %{
+          headers: [{"traceparent", :longstr, first_traceparent}],
+          delivery_tag: 1
+        },
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      },
+      %Broadway.Message{
+        data: "second",
+        metadata: %{
+          headers: [{"traceparent", :longstr, second_traceparent}],
+          message_id: "msg-2"
+        },
+        acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+      }
+    ]
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :start],
+      %{},
+      %{
+        topology_name: :test_topology,
+        name: :"test_topology.Broadway.BatchProcessor_0",
+        messages: messages,
+        batch_info: %{batcher: :default}
+      }
+    )
+
+    :telemetry.execute(
+      [:broadway, :batch_processor, :stop],
+      %{},
+      %{successful_messages: messages, failed_messages: []}
+    )
+
+    assert_receive {:span, span(name: ":test_topology/default batch", links: links)}
+
+    assert [first_link, second_link] =
+             elem(links, 5)
+             |> Enum.sort_by(fn link -> :otel_attributes.map(elem(link, 3))[:"messaging.message.id"] end)
+
+    assert link(trace_id: ^first_trace_id, span_id: ^first_span_id, attributes: first_attrs) = first_link
+    assert link(trace_id: ^second_trace_id, span_id: ^second_span_id, attributes: second_attrs) = second_link
+
+    assert :otel_attributes.map(first_attrs) == %{"messaging.message.id": "1"}
+    assert :otel_attributes.map(second_attrs) == %{"messaging.message.id": "msg-2"}
+  end
+
   test "batch processor span has no links when propagation is disabled" do
     TestHelpers.remove_handlers()
     :ok = OpentelemetryBroadway.setup(propagation: false)
@@ -410,11 +466,9 @@ defmodule OpentelemetryBroadwayTest do
     assert attrs_map[:"messaging.message.body.size"] == byte_size("test message")
     assert attrs_map[:"messaging.message.id"] == "123"
 
-    links_list = elem(links, 5)
-    assert length(links_list) == 1
-    [link] = links_list
-    assert elem(link, 1) == trace_id
-    assert elem(link, 2) == span_id
+    assert [propagated_link] = elem(links, 5)
+    assert link(trace_id: ^trace_id, span_id: ^span_id, attributes: link_attrs) = propagated_link
+    assert :otel_attributes.map(link_attrs) == %{"messaging.message.id": "123"}
   end
 
   test "creates proper trace relationship when propagation enabled" do


### PR DESCRIPTION
- Batch spans aggregate links from many source messages; without per-link attributes, consumers can't tell which link points to which message after the fact.
- Identifying attributes (`messaging.message.id`, `messaging.message.body.size`) belong on the link itself rather than only on the per-message span, so the batch span remains useful in isolation.