### PR TITLE
fix(opentelemetry_oban): guard nil :jobs in Cron plugin stop attributes

### DIFF
--- a/instrumentation/opentelemetry_oban/CHANGELOG.md
+++ b/instrumentation/opentelemetry_oban/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* Fix `OpentelemetryOban.PluginHandler` crashing with `:badarg` when an
+  `Oban.Plugins.Cron` (or `Oban.Pro.Plugins.DynamicCron`) `[:oban, :plugin, :stop]`
+  event carries no `:jobs` in its metadata. Oban omits `:jobs` when the scheduled
+  insert fails (e.g. a transient DB error), so `length(metadata[:jobs])` raised on
+  `nil` and `:telemetry` detached the handler, silently disabling plugin tracing
+  until the next restart. `jobs_count` now defaults to `0`.
+
 ## 1.1.1
 
 ### Fixed

--- a/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/plugin_handler.ex
+++ b/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/plugin_handler.ex
@@ -84,7 +84,7 @@ defmodule OpentelemetryOban.PluginHandler do
   defp set_error_type(_error), do: :ok
 
   defp end_span_plugin_attrs(%{plugin: Oban.Plugins.Cron} = metadata) do
-    %{"oban.plugins.cron.jobs_count": length(metadata[:jobs])}
+    %{"oban.plugins.cron.jobs_count": length(metadata[:jobs] || [])}
   end
 
   defp end_span_plugin_attrs(%{plugin: Oban.Plugins.Gossip} = metadata) do
@@ -103,7 +103,7 @@ defmodule OpentelemetryOban.PluginHandler do
   end
 
   defp end_span_plugin_attrs(%{plugin: Oban.Pro.Plugins.DynamicCron} = metadata) do
-    %{"oban.pro.plugins.dynamic_cron.jobs_count": length(metadata[:jobs])}
+    %{"oban.pro.plugins.dynamic_cron.jobs_count": length(metadata[:jobs] || [])}
   end
 
   defp end_span_plugin_attrs(%{plugin: Oban.Pro.Plugins.DynamicLifeline} = metadata) do

--- a/instrumentation/opentelemetry_oban/test/opentelemetry_oban/plugin_handler_test.exs
+++ b/instrumentation/opentelemetry_oban/test/opentelemetry_oban/plugin_handler_test.exs
@@ -173,6 +173,20 @@ defmodule OpentelemetryOban.PluginHandlerTest do
                receive_span_attrs(Oban.Plugins.Cron)
     end
 
+    test "Oban.Plugins.Cron plugin without :jobs in metadata" do
+      # Oban omits :jobs from the [:oban, :plugin, :stop] metadata when the
+      # scheduled insert fails (Oban.Plugins.Cron returns {:error, meta} with an
+      # :error key and no :jobs). jobs_count must default to 0 rather than crash
+      # the telemetry handler on length(nil), which would detach it.
+      execute_plugin(Oban.Plugins.Cron, %{error: %RuntimeError{message: "insert failed"}})
+
+      assert %{
+               "oban.plugin": Elixir.Oban.Plugins.Cron,
+               "oban.plugins.cron.jobs_count": 0
+             } ==
+               receive_span_attrs(Oban.Plugins.Cron)
+    end
+
     test "Oban.Plugins.Gossip plugin" do
       execute_plugin(Oban.Plugins.Gossip, %{gossip_count: 3})
 
@@ -210,6 +224,18 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       assert %{
                "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicCron,
                "oban.pro.plugins.dynamic_cron.jobs_count": 3
+             } ==
+               receive_span_attrs(Oban.Pro.Plugins.DynamicCron)
+    end
+
+    test "Oban.Pro.Plugins.DynamicCron plugin without :jobs in metadata" do
+      execute_plugin(Oban.Pro.Plugins.DynamicCron, %{
+        error: %RuntimeError{message: "insert failed"}
+      })
+
+      assert %{
+               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicCron,
+               "oban.pro.plugins.dynamic_cron.jobs_count": 0
              } ==
                receive_span_attrs(Oban.Pro.Plugins.DynamicCron)
     end


### PR DESCRIPTION
## Problem

`OpentelemetryOban.PluginHandler` crashes with `:badarg` when an
`Oban.Plugins.Cron` (or `Oban.Pro.Plugins.DynamicCron`) `[:oban, :plugin, :stop]`
event carries no `:jobs` in its metadata:

```
Handler "Elixir.OpentelemetryOban.PluginHandler.plugin_stop" has failed and has been detached.
Class=:error Reason=:badarg
  {:erlang, :length, [nil], ...}
  {OpentelemetryOban.PluginHandler, :end_span_plugin_attrs, 1, [line: 87]}
```

Because `:telemetry` detaches any handler that raises, this **silently disables
OpentelemetryOban plugin tracing on that node until the next restart**.

## Root cause

`Oban.Plugins.Cron` only adds `:jobs` to the stop metadata on the success path.
When the scheduled insert fails — e.g. a transient DB error — it returns
`{:error, Map.put(meta, :error, error)}` with **no** `:jobs` key. `end_span_plugin_attrs/1`
then evaluates `length(metadata[:jobs])` = `length(nil)` → `:badarg`.

This is the same DB-error scenario reported in #322. #392 fixed the related
`:function_clause` crash on that path but left this `length(nil)` `:badarg` in the
`Cron`/`DynamicCron` attribute builders.

## Fix

Guard the two `length/1` calls with `metadata[:jobs] || []`, so `jobs_count`
defaults to `0` instead of crashing.

## Tests

Adds regression tests for the no-`:jobs` stop event for both `Oban.Plugins.Cron`
and `Oban.Pro.Plugins.DynamicCron`. Without the fix they reproduce the production
`:badarg` detach; with it the full suite passes (15/15 plugin handler, 42/42 overall).

---

Note: I verified locally, but `main` does not currently compile on Elixir 1.20.x due
to an unrelated `insert/5` & `insert_all/5` default-argument conflict
(`def insert/5 defaults conflicts with insert/3`) — 1.20 promotes this from a warning
to an error. Happy to open a separate issue/PR for that.
