### PR TITLE
fix(ci): resolve release-drafter _extends from repo root

### DIFF
--- a/.github/release-drafter-templates/opentelemetry-aws-xray.yml
+++ b/.github/release-drafter-templates/opentelemetry-aws-xray.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry AWS X-Ray - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-aws-xray-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-aws-xray-v

--- a/.github/release-drafter-templates/opentelemetry-bandit.yml
+++ b/.github/release-drafter-templates/opentelemetry-bandit.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Bandit - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-bandit-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-bandit-v

--- a/.github/release-drafter-templates/opentelemetry-broadway.yml
+++ b/.github/release-drafter-templates/opentelemetry-broadway.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Broadway - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-broadway-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-broadway-v

--- a/.github/release-drafter-templates/opentelemetry-commanded.yml
+++ b/.github/release-drafter-templates/opentelemetry-commanded.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: "Opentelemetry Commanded - v$RESOLVED_VERSION"
 tag-template: "opentelemetry-commanded-v$RESOLVED_VERSION"
 tag-prefix: opentelemetry-commanded-v

--- a/.github/release-drafter-templates/opentelemetry-cowboy.yml
+++ b/.github/release-drafter-templates/opentelemetry-cowboy.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Cowboy - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-cowboy-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-cowboy-v

--- a/.github/release-drafter-templates/opentelemetry-dataloader.yml
+++ b/.github/release-drafter-templates/opentelemetry-dataloader.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Dataloader - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-dataloader-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-dataloader-v

--- a/.github/release-drafter-templates/opentelemetry-ecto.yml
+++ b/.github/release-drafter-templates/opentelemetry-ecto.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Ecto - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-ecto-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-ecto-v

--- a/.github/release-drafter-templates/opentelemetry-elli.yml
+++ b/.github/release-drafter-templates/opentelemetry-elli.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Elli - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-elli-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-elli-v

--- a/.github/release-drafter-templates/opentelemetry-finch.yml
+++ b/.github/release-drafter-templates/opentelemetry-finch.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Finch - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-finch-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-finch-v

--- a/.github/release-drafter-templates/opentelemetry-grpc.yml
+++ b/.github/release-drafter-templates/opentelemetry-grpc.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry gRPC - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-grpc-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-grpc-v

--- a/.github/release-drafter-templates/opentelemetry-grpcbox.yml
+++ b/.github/release-drafter-templates/opentelemetry-grpcbox.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry GRPCBox - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-grpcbox-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-grpcbox-v

--- a/.github/release-drafter-templates/opentelemetry-httpoison.yml
+++ b/.github/release-drafter-templates/opentelemetry-httpoison.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry HTTPoison - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-httpoison-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-httpoison-v

--- a/.github/release-drafter-templates/opentelemetry-nebulex.yml
+++ b/.github/release-drafter-templates/opentelemetry-nebulex.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Nebulex - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-nebulex-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-nebulex-v

--- a/.github/release-drafter-templates/opentelemetry-oban.yml
+++ b/.github/release-drafter-templates/opentelemetry-oban.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Oban - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-oban-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-oban-v

--- a/.github/release-drafter-templates/opentelemetry-phoenix.yml
+++ b/.github/release-drafter-templates/opentelemetry-phoenix.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Phoenix - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-phoenix-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-phoenix-v

--- a/.github/release-drafter-templates/opentelemetry-process-propagator.yml
+++ b/.github/release-drafter-templates/opentelemetry-process-propagator.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Process Propagator - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-process-propagator-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-process-propagator-v

--- a/.github/release-drafter-templates/opentelemetry-redix.yml
+++ b/.github/release-drafter-templates/opentelemetry-redix.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Redix - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-redix-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-redix-v

--- a/.github/release-drafter-templates/opentelemetry-req.yml
+++ b/.github/release-drafter-templates/opentelemetry-req.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Req - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-req-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-req-v

--- a/.github/release-drafter-templates/opentelemetry-telemetry.yml
+++ b/.github/release-drafter-templates/opentelemetry-telemetry.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Telemetry - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-telemetry-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-telemetry-v

--- a/.github/release-drafter-templates/opentelemetry-tesla.yml
+++ b/.github/release-drafter-templates/opentelemetry-tesla.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Opentelemetry Tesla - v$RESOLVED_VERSION'
 tag-template: 'opentelemetry-tesla-v$RESOLVED_VERSION'
 tag-prefix: opentelemetry-tesla-v

--- a/.github/release-drafter-templates/opentelemetry-xandra.yml
+++ b/.github/release-drafter-templates/opentelemetry-xandra.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: "Opentelemetry Xandra - v$RESOLVED_VERSION"
 tag-template: "opentelemetry-xandra-v$RESOLVED_VERSION"
 tag-prefix: opentelemetry-xandra-v

--- a/.github/release-drafter-templates/otel-http.yml
+++ b/.github/release-drafter-templates/otel-http.yml
@@ -1,4 +1,4 @@
-_extends: opentelemetry-erlang-contrib:.github/release-drafter.yml
+_extends: opentelemetry-erlang-contrib:/.github/release-drafter.yml
 name-template: 'Otel HTTP - v$RESOLVED_VERSION'
 tag-template: 'otel-http-v$RESOLVED_VERSION'
 tag-prefix: otel-http-v


### PR DESCRIPTION
- The `Release Drafter` workflow has failed on every `main` push since release-drafter was bumped v6 -> v7 (#650), blocking release note drafting for all packages.
- v7 resolves same-repo `_extends` paths relative to the extending file's directory instead of the repo root, so every template in `.github/release-drafter-templates/` looked for the shared base config at a path that does not exist (404).
- Anchoring the `_extends` path to the repo root restores the previous, working resolution.