### PR TITLE
Remove Greg Mefford from emeritus status

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ We'd love your help!. Use tags [up-for-grabs][up-for-grabs-issues] and
 ### Emeritus
 
 - [Andrea Leopardi](https://github.com/whatyouhide), Approver
-- [Greg Mefford](https://github.com/GregMefford), Approver
 
 For more information about the emeritus role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).


### PR DESCRIPTION
I intend to continue to contribute actively as an Approver, I just didn't get a chance to intercept this change before it got merged.