### PR TITLE
chore: Docker housekeeping

### DIFF
--- a/examples/roll_dice/docker-compose.yml
+++ b/examples/roll_dice/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   otel:
-    image: otel/opentelemetry-collector-contrib:0.76.1
+    image: otel/opentelemetry-collector-contrib:0.156.0
     command: ["--config=/conf/otel-collector-config.yaml"]
     privileged: true
     ports:
@@ -14,7 +14,7 @@ services:
       - jaeger-all-in-one
 
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:1.45
+    image: jaegertracing/jaeger:2.19.0
     restart: always
     environment:
       COLLECTOR_OTLP_ENABLED: true

--- a/examples/roll_dice_elli/docker-compose.yml
+++ b/examples/roll_dice_elli/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   otel:
-    image: otel/opentelemetry-collector-contrib:0.134.1
+    image: otel/opentelemetry-collector-contrib:0.156.0
     command: ["--config=/conf/otel-collector-config.yaml"]
     privileged: true
     ports:
@@ -13,7 +13,7 @@ services:
       - jaeger-all-in-one
 
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:1.64.0
+    image: jaegertracing/jaeger:2.19.0
     restart: always
     environment:
       COLLECTOR_OTLP_ENABLED: true

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "ignorePaths":[],
   "labels": ["renovate"],
   "schedule": ["before 6am on monday"],
   "prConcurrentLimit": 10,


### PR DESCRIPTION
Explicitly pin docker version to improve info/context available to renovate.

The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321

Note renovate has been configured to also update filed in the examples dir.