### PR TITLE
fix: prevent renovate from pinning hex dependency semver ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":preserveSemverRanges"
   ],
   "ignorePaths":[],
   "labels": ["renovate"],


### PR DESCRIPTION
## Summary

#566 switched the Renovate config to extend `config:best-practices`, which includes pinning behavior for hex dependency semver ranges (e.g. `~> 0.10` → `== 0.10.0`), which is undesirable.

As noted in Renovate's own docs:

> Add the preset `:preserveSemverRanges` to your config if you don't want to pin your dependencies.

This PR adds that preset to `renovate.json` to restore the previous, non-pinning behavior for dependency version ranges, matching the same fix applied upstream in open-telemetry/opentelemetry-erlang#1022.

## Test plan

- [ ] Confirm Renovate no longer proposes pinning existing semver ranges on its next run