### PR TITLE
fix(opentelemetry_dataloader): keep self-attached context instead of a more distant $callers ancestor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,4 @@ Technical specifications:
 - [Configuration Options](reference/configuration-options.md): standard option types, defaults, naming conventions, SemConv requirement level mapping, and package support matrix
 - [Custom Span Attributes](reference/custom-span-attributes.md): how to define package-specific span attributes using a `[Component]Attributes` module
 - [Recording Exceptions](reference/recording-exceptions.md): exception event fields, span status description strings, `error.type` values, and `erlang.exception.kind`
+- [Context Propagation Precedence](reference/context-propagation.md): why `:telemetry` handlers must check for an already-attached context before falling back to a `$callers` ancestor

--- a/docs/reference/context-propagation.md
+++ b/docs/reference/context-propagation.md
@@ -1,0 +1,55 @@
+# Context propagation precedence
+
+Specification for resolving the parent OTel context in `:telemetry` handlers
+that run in a different process than the one that emitted the event.
+
+## Mechanisms
+
+| Mechanism | Role |
+| --------- | ---- |
+| `OpentelemetryProcessPropagator.fetch_ctx/1` | Reads the OTel context already attached to a given pid's process dictionary (`$__current_otel_ctx`). |
+| `OpentelemetryProcessPropagator.fetch_parent_ctx/2` | Walks the `$callers` (or other configured key) process-dictionary chain, up to `MaxDepth` ancestors, and returns the first attached context found. |
+| `OpenTelemetry.Ctx.attach/1` | Makes a context current for the calling process; returns a token for detaching later. |
+
+## The precedence guard
+
+A `:telemetry` handler runs in whatever process emitted the event. That
+process may already have its own context attached — for example, another
+instrumentation package already started a span there. `fetch_parent_ctx/2`
+does not know about that: it only walks `$callers`, so it can return a more
+distant ancestor's context even when a closer, already-current one exists.
+
+Handlers that call `fetch_parent_ctx/2` unconditionally therefore risk
+overwriting a closer, correct parent with a more distant one, misparenting
+the span it's about to start. The guard checks `fetch_ctx(self())` first and
+only falls back to the `$callers` walk when nothing is attached locally:
+
+```elixir
+parent_ctx =
+  case OpentelemetryProcessPropagator.fetch_ctx(self()) do
+    :undefined -> OpentelemetryProcessPropagator.fetch_parent_ctx(depth, :"$callers")
+    ctx -> ctx
+  end
+
+if parent_ctx != :undefined do
+  OpenTelemetry.Ctx.attach(parent_ctx)
+end
+```
+
+## Packages implementing the guard
+
+| Package | `MaxDepth` | Handler(s) |
+| ------- | ---------- | ---------- |
+| `opentelemetry_ecto` | 1 | query span start |
+| `opentelemetry_redix` | 1 | command span start |
+| `opentelemetry_dataloader` | 4 | `run` and `batch` span start |
+
+## Failure mode without the guard
+
+Concretely: a process starts a span (e.g. Absinthe resolving a field), then
+calls into Dataloader, which schedules work through `$callers`-tracked
+processes. A handler that calls `fetch_parent_ctx/2` unconditionally
+overwrites the Absinthe-attached context with whatever it finds walking
+`$callers`, so the resulting span attaches to the wrong ancestor
+(`Phoenix -> Dataloader` instead of `Phoenix -> Absinthe -> Dataloader`).
+The guard preserves the closer, already-attached context instead.

--- a/instrumentation/opentelemetry_dataloader/lib/opentelemetry_dataloader.ex
+++ b/instrumentation/opentelemetry_dataloader/lib/opentelemetry_dataloader.ex
@@ -45,7 +45,11 @@ defmodule OpentelemetryDataloader do
   def handle_event(event, measurements, metadata, config)
 
   def handle_event(@run_start, _measurements, metadata, config) do
-    parent_ctx = OpentelemetryProcessPropagator.fetch_parent_ctx(4, :"$callers")
+    parent_ctx =
+      case OpentelemetryProcessPropagator.fetch_ctx(self()) do
+        :undefined -> OpentelemetryProcessPropagator.fetch_parent_ctx(4, :"$callers")
+        ctx -> ctx
+      end
 
     if parent_ctx != :undefined do
       OpenTelemetry.Ctx.attach(parent_ctx)
@@ -68,7 +72,11 @@ defmodule OpentelemetryDataloader do
   end
 
   def handle_event(@batch_start, _measurements, metadata, config) do
-    parent_ctx = OpentelemetryProcessPropagator.fetch_parent_ctx(4, :"$callers")
+    parent_ctx =
+      case OpentelemetryProcessPropagator.fetch_ctx(self()) do
+        :undefined -> OpentelemetryProcessPropagator.fetch_parent_ctx(4, :"$callers")
+        ctx -> ctx
+      end
 
     if parent_ctx != :undefined do
       OpenTelemetry.Ctx.attach(parent_ctx)

--- a/instrumentation/opentelemetry_dataloader/test/opentelemetry_dataloader_test.exs
+++ b/instrumentation/opentelemetry_dataloader/test/opentelemetry_dataloader_test.exs
@@ -66,4 +66,44 @@ defmodule OpentelemetryDataloaderTest do
     assert %{"dataloader.batch_key" => key} = :otel_attributes.map(attributes)
     assert key =~ ~r/OpentelemetryDataloader.TestModels.Post/
   end
+
+  test "keeps a context already attached to self instead of a more distant $callers ancestor" do
+    test_pid = self()
+
+    ancestor_pid =
+      spawn(fn ->
+        "ancestor" |> OpenTelemetry.Tracer.start_span() |> OpenTelemetry.Tracer.set_current_span()
+
+        ancestor_trace_id =
+          OpenTelemetry.Tracer.current_span_ctx() |> OpenTelemetry.Span.trace_id()
+
+        send(test_pid, {:ancestor_trace_id, ancestor_trace_id})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive {:ancestor_trace_id, ancestor_trace_id}
+
+    Process.put(:"$callers", [ancestor_pid])
+    "self" |> OpenTelemetry.Tracer.start_span() |> OpenTelemetry.Tracer.set_current_span()
+    self_trace_id = OpenTelemetry.Tracer.current_span_ctx() |> OpenTelemetry.Span.trace_id()
+
+    OpentelemetryDataloader.handle_event(
+      [:dataloader, :source, :run, :start],
+      %{},
+      %{},
+      %{tracer_id: OpentelemetryDataloader}
+    )
+
+    run_trace_id = OpenTelemetry.Tracer.current_span_ctx() |> OpenTelemetry.Span.trace_id()
+
+    assert run_trace_id == self_trace_id
+    refute run_trace_id == ancestor_trace_id
+
+    send(ancestor_pid, :stop)
+    OpenTelemetry.Tracer.end_span()
+    OpenTelemetry.Tracer.end_span()
+  end
 end


### PR DESCRIPTION
- Unconditionally overwriting an already-attached context with a more distant `$callers` ancestor misparents Dataloader spans whenever another library (e.g. Absinthe) already started a span in the same process, breaking the trace hierarchy (`Phoenix -> Dataloader` instead of `Phoenix -> Absinthe -> Dataloader`). `opentelemetry_ecto` already guards against this same class of bug.
- Supersedes #162, which proposed the same fix for `run_start` but left `batch_start` with the same bug and shipped no regression test. This applies the guard to both handlers and adds a test that reproduces the misparenting on unpatched code and confirms it's fixed.