### PR TITLE
chore(renovate): pin elixir/erlang constraints

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,18 +19,20 @@
   },
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": ["/^renovate\\.json$/"],
-      "matchStrings": ["\"elixir\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "matchStrings": ["{ \"currentValue\": constraints.elixir }"],
       "depNameTemplate": "elixir-lang/elixir",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
     },
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": ["/^renovate\\.json$/"],
-      "matchStrings": ["\"erlang\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "matchStrings": ["{ \"currentValue\": constraints.erlang }"],
       "depNameTemplate": "erlang/otp",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "loose",
@@ -39,7 +41,7 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["custom.regex"],
+      "matchManagers": ["custom.jsonata"],
       "matchDepNames": ["elixir-lang/elixir", "erlang/otp"],
       "dependencyDashboardApproval": true,
       "groupName": "renovate toolchain constraints",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     ":preserveSemverRanges"
   ],
   "ignorePaths":[],
+  "constraints": {
+    "elixir": "1.18.2",
+    "erlang": "27.2.4"
+  },
   "labels": ["renovate"],
   "schedule": ["before 6am on monday"],
   "prConcurrentLimit": 10,

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,34 @@
   "vulnerabilityAlerts": {
     "schedule": ["at any time"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^renovate\\.json$/"],
+      "matchStrings": ["\"elixir\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "elixir-lang/elixir",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^renovate\\.json$/"],
+      "matchStrings": ["\"erlang\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "erlang/otp",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^OTP-(?<version>.+)$"
+    }
+  ],
   "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["elixir-lang/elixir", "erlang/otp"],
+      "dependencyDashboardApproval": true,
+      "groupName": "renovate toolchain constraints",
+      "addLabels": ["chore"]
+    },
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "groupName": "patch updates",


### PR DESCRIPTION
- Lock file maintenance PRs (e.g. #758) fail the `renovate/artifacts` check because Renovate tries to install the newest Elixir release to regenerate every `mix.lock`, and that install fails whenever the release is too new for Renovate's tool installer to have registered its OTP requirement yet (same root cause as renovatebot/renovate discussion #38668 for Elixir 1.19). Pinning constraints to versions already validated in `.github/elixir-test-matrix.json` keeps lock file maintenance on a known-good toolchain.
- A static pin goes stale silently, so a JSONata custom manager reads the pinned Elixir/OTP values straight out of this file's parsed structure and tracks them against their GitHub releases, opening a dashboard-gated PR when new ones land, keeping the toolchain current without risking another broken lock-file-maintenance run.