### PR TITLE
test(oban): test cover recording of throws/exits exceptions

### DIFF
--- a/instrumentation/opentelemetry_oban/test/opentelemetry_oban_test.exs
+++ b/instrumentation/opentelemetry_oban/test/opentelemetry_oban_test.exs
@@ -273,7 +273,7 @@ defmodule OpentelemetryObanTest do
   end
 
   test "records spans for Oban jobs that stop with an exception" do
-    {:ok, %{id: id}} = OpentelemetryOban.insert(TestJobThatThrowsException.new(%{}))
+    {:ok, %{id: id}} = OpentelemetryOban.insert(TestJobThatRaisesException.new(%{}))
     assert %{success: 0, discard: 1} = Oban.drain_queue(queue: :events)
 
     expected_status = OpenTelemetry.status(:error, "")
@@ -298,10 +298,10 @@ defmodule OpentelemetryObanTest do
              "oban.job.max_attempts": 1,
              "oban.job.priority": 0,
              "oban.job.scheduled_at": _scheduled_at,
-             "oban.job.worker": "TestJobThatThrowsException",
+             "oban.job.worker": "TestJobThatRaisesException",
              "messaging.operation.type": :process,
              "messaging.message.id": ^id,
-             "messaging.client.id": "TestJobThatThrowsException",
+             "messaging.client.id": "TestJobThatRaisesException",
              "messaging.system": :oban,
              "error.type": "UndefinedFunctionError"
            } = attrs
@@ -315,6 +315,102 @@ defmodule OpentelemetryObanTest do
 
     assert [:"exception.message", :"exception.stacktrace", :"exception.type"] ==
              Enum.sort(Map.keys(:otel_attributes.map(event_attributes)))
+  end
+
+  test "records spans for Oban jobs that stop with an unhandled throw" do
+    {:ok, %{id: id}} = OpentelemetryOban.insert(TestJobThatThrowsValue.new(%{}))
+    assert %{success: 0, discard: 1} = Oban.drain_queue(queue: :events)
+
+    expected_status = OpenTelemetry.status(:error, "")
+
+    assert_receive {:span,
+                    span(
+                      name: "process events",
+                      attributes: attributes,
+                      kind: :consumer,
+                      events: events,
+                      status: ^expected_status
+                    )}
+
+    attrs = :otel_attributes.map(attributes)
+
+    assert %{
+             "messaging.destination.name": "events",
+             "messaging.operation.name": "process",
+             "oban.job.attempt": 1,
+             "oban.job.inserted_at": _inserted_at,
+             "oban.job.job_id": ^id,
+             "oban.job.max_attempts": 1,
+             "oban.job.priority": 0,
+             "oban.job.scheduled_at": _scheduled_at,
+             "oban.job.worker": "TestJobThatThrowsValue",
+             "messaging.operation.type": :process,
+             "messaging.message.id": ^id,
+             "messaging.client.id": "TestJobThatThrowsValue",
+             "messaging.system": :oban,
+             "error.type": "Oban.CrashError"
+           } = attrs
+
+    [
+      event(
+        name: :exception,
+        attributes: event_attributes
+      )
+    ] = :otel_events.list(events)
+
+    assert %{
+             :"exception.type" => "Elixir.Oban.CrashError",
+             :"exception.message" => "** (throw) \"value\"",
+             :"exception.stacktrace" => _
+           } = :otel_attributes.map(event_attributes)
+  end
+
+  test "records spans for Oban jobs that stop with an abnormal exit" do
+    {:ok, %{id: id}} = OpentelemetryOban.insert(TestJobThatExitsAbnormally.new(%{}))
+    assert %{success: 0, discard: 1} = Oban.drain_queue(queue: :events)
+
+    expected_status = OpenTelemetry.status(:error, "")
+
+    assert_receive {:span,
+                    span(
+                      name: "process events",
+                      attributes: attributes,
+                      kind: :consumer,
+                      events: events,
+                      status: ^expected_status
+                    )}
+
+    attrs = :otel_attributes.map(attributes)
+
+    assert %{
+             "messaging.destination.name": "events",
+             "messaging.operation.name": "process",
+             "oban.job.attempt": 1,
+             "oban.job.inserted_at": _inserted_at,
+             "oban.job.job_id": ^id,
+             "oban.job.max_attempts": 1,
+             "oban.job.priority": 0,
+             "oban.job.scheduled_at": _scheduled_at,
+             "oban.job.worker": "TestJobThatExitsAbnormally",
+             "messaging.operation.type": :process,
+             "messaging.message.id": ^id,
+             "messaging.client.id": "TestJobThatExitsAbnormally",
+             "messaging.system": :oban,
+             "error.type": "Oban.CrashError"
+           } = attrs
+
+    [
+      event(
+        name: :exception,
+        attributes: event_attributes
+      )
+    ] = :otel_events.list(events)
+
+    assert %{
+             :"exception.type" => "Elixir.Oban.CrashError",
+             :"exception.message" => "** (exit) :abnormal",
+             :"exception.stacktrace" => _
+           } = :otel_attributes.map(event_attributes)
   end
 
   test "spans inside the job are associated with the job trace" do

--- a/instrumentation/opentelemetry_oban/test/support/jobs/test_job_that_exits_abnormally.ex
+++ b/instrumentation/opentelemetry_oban/test/support/jobs/test_job_that_exits_abnormally.ex
@@ -1,0 +1,8 @@
+defmodule TestJobThatExitsAbnormally do
+  use Oban.Worker, queue: :events, max_attempts: 1
+
+  @impl Oban.Worker
+  def perform(_job) do
+    exit(:abnormal)
+  end
+end

--- a/instrumentation/opentelemetry_oban/test/support/jobs/test_job_that_raises_exception.ex
+++ b/instrumentation/opentelemetry_oban/test/support/jobs/test_job_that_raises_exception.ex
@@ -1,4 +1,4 @@
-defmodule TestJobThatThrowsException do
+defmodule TestJobThatRaisesException do
   use Oban.Worker, queue: :events, max_attempts: 1
 
   @impl Oban.Worker

--- a/instrumentation/opentelemetry_oban/test/support/jobs/test_job_that_throws_value.ex
+++ b/instrumentation/opentelemetry_oban/test/support/jobs/test_job_that_throws_value.ex
@@ -1,0 +1,8 @@
+defmodule TestJobThatThrowsValue do
+  use Oban.Worker, queue: :events, max_attempts: 1
+
+  @impl Oban.Worker
+  def perform(_job) do
+    throw("value")
+  end
+end


### PR DESCRIPTION
- Supersedes #648, which could not be updated to resolve merge conflicts; this ports the same change (authored by @grzuy, credit preserved via cherry-pick) onto the restructured Oban test layout.
- Unhandled throws and abnormal exits are wrapped by Oban in `Oban.CrashError`, and the instrumentation records them as span exceptions; this behavior had no test coverage.
- `TestJobThatThrowsException` actually raises rather than throws, so it is renamed to `TestJobThatRaisesException` to keep the new throw test unambiguous.