### PR TITLE
Limit approval to major/minor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,16 +40,17 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["custom.jsonata"],
-      "matchDepNames": ["elixir-lang/elixir", "containerbase/erlang-prebuild"],
-      "dependencyDashboardApproval": true,
-      "groupName": "renovate toolchain constraints",
-      "addLabels": ["chore"]
-    },
-    {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "groupName": "patch updates",
       "addLabels": ["patch", "chore", "skip-changelog"]
+    },
+    {
+      "matchManagers": ["custom.jsonata"],
+      "matchDepNames": ["elixir-lang/elixir", "containerbase/erlang-prebuild"],
+      "matchUpdateTypes": ["major", "minor"],
+      "dependencyDashboardApproval": true,
+      "groupName": "renovate toolchain constraints",
+      "addLabels": ["chore"]
     },
     {
       "matchDatasources": ["hex"],

--- a/renovate.json
+++ b/renovate.json
@@ -40,17 +40,17 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "groupName": "patch updates",
-      "addLabels": ["patch", "chore", "skip-changelog"]
-    },
-    {
       "matchManagers": ["custom.jsonata"],
       "matchDepNames": ["elixir-lang/elixir", "containerbase/erlang-prebuild"],
       "matchUpdateTypes": ["major", "minor"],
       "dependencyDashboardApproval": true,
       "groupName": "renovate toolchain constraints",
       "addLabels": ["chore"]
+    },
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "groupName": "patch updates",
+      "addLabels": ["patch", "chore", "skip-changelog"]
     },
     {
       "matchDatasources": ["hex"],


### PR DESCRIPTION
This unblock patch updates from needing approval by ensuring major/minor only need approval.