### PR TITLE
increase docker pinning

### DIFF
--- a/examples/basic_elixir/Dockerfile
+++ b/examples/basic_elixir/Dockerfile
@@ -1,11 +1,11 @@
-FROM elixir:1.20-alpine@sha256:ef915e5ab96e620116058c3b6002510227e4f5b57ca782296e675ee4e83d7344 as builder
+FROM elixir:1.20.2-alpine@sha256:ef915e5ab96e620116058c3b6002510227e4f5b57ca782296e675ee4e83d7344 as builder
 RUN mix local.hex --force && mix local.rebar --force
 WORKDIR /app
 COPY . /app
 RUN mix deps.get
 RUN MIX_ENV=prod mix release
 
-FROM elixir:1.20-alpine@sha256:ef915e5ab96e620116058c3b6002510227e4f5b57ca782296e675ee4e83d7344 as app
+FROM elixir:1.20.2-alpine@sha256:ef915e5ab96e620116058c3b6002510227e4f5b57ca782296e675ee4e83d7344 as app
 WORKDIR /app
 COPY --from=builder /app/_build/prod/rel/basic_elixir .
 CMD bin/basic_elixir start

--- a/examples/basic_elixir/docker-compose.yml
+++ b/examples/basic_elixir/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
 
   otel:
-    image: otel/opentelemetry-collector-contrib-dev:latest@sha256:bbebdda8aa57c5bac5a98570bdc94872b7fdf56b93e7b5e25906843012589e92
+    image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
     command: ["--config=/etc/otel-collector-config.yaml"]
     ports:
       - '55681:55681'
@@ -13,13 +13,13 @@ services:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
 
   zipkin:
-    image: openzipkin/zipkin-slim@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
+    image: openzipkin/zipkin-slim:3.6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     ports:
       - '9411:9411'
 
   # Jaeger
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:latest@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
     ports:
       - "16686:16686"
       - "14268"

--- a/examples/basic_phoenix_ecto/docker-compose.yaml
+++ b/examples/basic_phoenix_ecto/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: 'postgres:latest@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a'
+    image: 'postgres:18.4@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a'
     ports:
       - 5432:5432
 
@@ -11,7 +11,7 @@ services:
       POSTGRES_DB: demo_dev
 
   otel:
-    image: otel/opentelemetry-collector-contrib-dev:latest@sha256:bbebdda8aa57c5bac5a98570bdc94872b7fdf56b93e7b5e25906843012589e92
+    image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
     command: ["--config=/etc/otel-collector-config.yaml"]
     ports:
       - "4318:4318"
@@ -25,14 +25,14 @@ services:
       - zipkin
 
   zipkin:
-    image: openzipkin/zipkin-slim@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
+    image: openzipkin/zipkin-slim:3.6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     container_name: "zipkin"
     ports:
       - '9411:9411'
 
   # Jaeger
   jaeger:
-    image: jaegertracing/all-in-one:latest@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
     container_name: "jaeger"
     ports:
       - "4317:4317"

--- a/instrumentation/opentelemetry_redix/docker-compose.yml
+++ b/instrumentation/opentelemetry_redix/docker-compose.yml
@@ -2,6 +2,6 @@ version: "3.7"
 
 services:
   redis:
-    image: redis:alpine@sha256:978f0e01593e65eed801f2402944efcd936d43b5027e4908a7897baf88ed6241
+    image: redis:8.10.0-alpine@sha256:978f0e01593e65eed801f2402944efcd936d43b5027e4908a7897baf88ed6241
     ports:
       - 6379:6379


### PR DESCRIPTION
This ensures docker images are pinned using semver to increase context in renovate pr’s and avoid major bumping of images via patch pr group.

Note both the collector & jaeger have been switched to a consistent version with the rest of the repo.