### PR TITLE
docs(opentelemetry_absinthe): add markdown formatter

### DIFF
--- a/instrumentation/opentelemetry_absinthe/CHANGELOG.md
+++ b/instrumentation/opentelemetry_absinthe/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Generate Markdown documentation with ExDoc.
+
 ---
 
 ## [2.4.0] - 2026-02-20

--- a/instrumentation/opentelemetry_absinthe/mix.exs
+++ b/instrumentation/opentelemetry_absinthe/mix.exs
@@ -34,7 +34,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
       main: "OpentelemetryAbsinthe",
       source_ref: @version,
       source_url: @source_url,
-      formatters: ["html"],
+      formatters: ["html", "markdown"],
       extras: ["README.md"]
     ]
   end


### PR DESCRIPTION
### What does this PR do?

Adds `markdown` to `opentelemetry_absinthe`'s explicit ExDoc formatter list and records the change in the package changelog.

ExDoc 0.40.0 added Markdown output and `llms.txt` to its defaults, but this package's explicit HTML-only list overrides those defaults. With this change, `mix docs` continues to generate HTML and also generates `llms.txt` plus Markdown pages.

This PR was generated from the findings in [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

### Verification

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix test` (33 tests, 0 failures)
- `mix dialyzer` (0 errors)
- `mix docs` (`doc/index.html`, `doc/llms.txt`, and Markdown pages generated)

— Oliver’s AMP