### PR TITLE
fix(opentelemetry_oban): report plugin failures and populate plugin counts

### DIFF
--- a/instrumentation/opentelemetry_oban/CHANGELOG.md
+++ b/instrumentation/opentelemetry_oban/CHANGELOG.md
@@ -11,6 +11,48 @@
   `nil` and `:telemetry` detached the handler, silently disabling plugin tracing
   until the next restart. `jobs_count` now defaults to `0`.
 
+* Report the real discarded and rescued counts for `Oban.Plugins.Lifeline` and
+  `Oban.Pro.Plugins.DynamicLifeline`. Both read `:discarded_count` and
+  `:rescued_count`, which Oban does not emit; the plugins report the
+  `:discarded_jobs` and `:rescued_jobs` lists instead. The attributes were
+  therefore always `nil`, which the exporter shipped as the string `"nil"` rather
+  than as a count.
+
+* Record `exception.message` on the `exception` event of plugin spans.
+  `OpentelemetryOban.PluginHandler` recorded exceptions through
+  `:otel_span.record_exception/5`, whose Erlang API cannot read an Elixir exception
+  struct: it recorded no `exception.message` and an `exception.type` holding an
+  inspected Erlang map rather than the exception module. Reasons are now normalised
+  with `Exception.normalize/3` and recorded through
+  `OpenTelemetry.Span.record_exception/4`. Reasons that cannot be normalised
+  (`:throw` and `:exit` kinds) still fall back to the Erlang API.
+
+* Mark plugin spans as errored when a `[:oban, :plugin, :stop]` event carries an
+  `:error`. Plugins report failure through the `{:error, meta}` return value of
+  `:telemetry.span/3`, which emits a `:stop` event rather than an `:exception`
+  event, so a failed plugin run produced a span with an `:unset` status that was
+  indistinguishable from success. Every plugin except `Oban.Stager` reports its
+  whole `{:error, reason}` return value, so the reason is unwrapped before the
+  status description and `error.type` are derived from it. A `nil` reason, which
+  `Oban.Plugins.Reindexer` reports on every non-leader node because it has no
+  `else` branch, is a no-op rather than a failure and is left unset.
+
+* Read job failure metadata from the documented `:reason` key in
+  `OpentelemetryOban.JobHandler`. It matched on `:error`, an undocumented alias
+  that Oban emits alongside `:reason`, so the handler would stop matching and
+  crash if Oban ever dropped it.
+
+### Changed
+
+* Emit plugin module names in their short form, without the BEAM-internal
+  `Elixir.` prefix. Both the `oban.plugin` attribute and the plugin span name
+  carried the module in a form the exporter renders as `"Elixir.Oban.Plugins.Cron"`.
+  The [Configuration Options](../../docs/reference/configuration-options.md)
+  reference requires the short form, and Oban itself already stores `worker` that
+  way, so the attribute is now `"Oban.Plugins.Cron"` and the span name is now
+  `"Oban.Plugins.Cron process"`. Consumers filtering on the prefixed attribute or
+  grouping on the prefixed span name must be updated.
+
 ## 1.1.1
 
 ### Fixed

--- a/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/job_handler.ex
+++ b/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/job_handler.ex
@@ -123,14 +123,14 @@ defmodule OpentelemetryOban.JobHandler do
   def handle_job_exception(
         _event,
         measurements,
-        %{stacktrace: stacktrace, error: error} = metadata,
+        %{stacktrace: stacktrace, reason: reason} = metadata,
         _config
       ) do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, metadata)
 
-    Span.record_exception(ctx, error, stacktrace)
+    Span.record_exception(ctx, reason, stacktrace)
     Span.set_status(ctx, OpenTelemetry.status(:error, ""))
-    set_error_type(error)
+    set_error_type(reason)
 
     set_measurements_attributes(measurements)
 

--- a/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/plugin_handler.ex
+++ b/instrumentation/opentelemetry_oban/lib/opentelemetry_oban/plugin_handler.ex
@@ -43,14 +43,15 @@ defmodule OpentelemetryOban.PluginHandler do
   def handle_plugin_start(_event, _measurements, %{plugin: plugin} = metadata, _config) do
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
-      "#{plugin} process",
+      "#{inspect(plugin)} process",
       metadata,
-      %{attributes: %{"oban.plugin": plugin}}
+      %{attributes: %{"oban.plugin": inspect(plugin)}}
     )
   end
 
   def handle_plugin_stop(_event, _measurements, metadata, _config) do
     Tracer.set_attributes(end_span_plugin_attrs(metadata))
+    maybe_record_stop_error(metadata)
     OpentelemetryTelemetry.end_telemetry_span(@tracer_id, metadata)
   end
 
@@ -62,21 +63,58 @@ defmodule OpentelemetryOban.PluginHandler do
       ) do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, metadata)
 
-    # Record exception and mark the span as errored
-    # We use :otel_span.record_exception/5 (Erlang) instead of Span.record_exception/3 (Elixir)
-    # because the Elixir version only works with exception structs (e.g., %RuntimeError{}),
-    # while the Erlang version handles ANY error reason (atoms like :badarg, tuples, etc.)
-    :otel_span.record_exception(ctx, kind, reason, stacktrace, [])
+    error = record_exception(ctx, kind, reason, stacktrace)
 
     Span.set_status(
       ctx,
       OpenTelemetry.status(:error, Exception.format_banner(kind, reason, stacktrace))
     )
 
-    set_error_type(reason)
+    set_error_type(error)
 
     OpentelemetryTelemetry.end_telemetry_span(@tracer_id, metadata)
   end
+
+  # `Exception.normalize/3` turns Erlang-style reasons (`:badarg`, `:undef`, ...) into Elixir
+  # exception structs, so `Span.record_exception/4` can record `exception.message`. Reasons that
+  # cannot be normalized (`:throw` and `:exit` kinds) fall back to the Erlang API, which accepts
+  # any term but records no message.
+  defp record_exception(ctx, kind, reason, stacktrace) do
+    case Exception.normalize(kind, reason, stacktrace) do
+      %{__exception__: true} = exception ->
+        Span.record_exception(ctx, exception, stacktrace, [])
+        exception
+
+      not_an_exception ->
+        :otel_span.record_exception(ctx, kind, reason, stacktrace, [])
+        not_an_exception
+    end
+  end
+
+  # Plugins report failure through the `{:error, meta}` return value of `:telemetry.span/3`, which
+  # emits a `:stop` event carrying `:error` instead of an `:exception` event.
+  #
+  # `Oban.Plugins.Reindexer` has no `else` branch for the non-leader case, so every follower node
+  # reports `nil` on each scheduled run. That is a no-op rather than a failure, and it carries no
+  # diagnostic value, so it is not recorded as an error.
+  defp maybe_record_stop_error(%{error: nil}), do: :ok
+
+  defp maybe_record_stop_error(%{error: error}) do
+    reason = unwrap_error(error)
+
+    Tracer.set_status(OpenTelemetry.status(:error, format_error(reason)))
+    set_error_type(reason)
+  end
+
+  defp maybe_record_stop_error(_metadata), do: :ok
+
+  # Most plugins put their whole `{:error, reason}` return value under `:error`; `Oban.Stager`
+  # destructures it and puts the bare reason.
+  defp unwrap_error({:error, reason}), do: reason
+  defp unwrap_error(error), do: error
+
+  defp format_error(error) when is_exception(error), do: Exception.message(error)
+  defp format_error(error), do: inspect(error)
 
   defp set_error_type(%struct_name{} = error) when is_exception(error),
     do: Tracer.set_attribute(ErrorAttributes.error_type(), inspect(struct_name))
@@ -93,8 +131,8 @@ defmodule OpentelemetryOban.PluginHandler do
 
   defp end_span_plugin_attrs(%{plugin: Oban.Plugins.Lifeline} = metadata) do
     %{
-      "oban.plugins.lifeline.discarded_count": metadata[:discarded_count],
-      "oban.plugins.lifeline.rescued_count": metadata[:rescued_count]
+      "oban.plugins.lifeline.discarded_count": length(metadata[:discarded_jobs] || []),
+      "oban.plugins.lifeline.rescued_count": length(metadata[:rescued_jobs] || [])
     }
   end
 
@@ -108,8 +146,9 @@ defmodule OpentelemetryOban.PluginHandler do
 
   defp end_span_plugin_attrs(%{plugin: Oban.Pro.Plugins.DynamicLifeline} = metadata) do
     %{
-      "oban.pro.plugins.dynamic_lifeline.discarded_count": metadata[:discarded_count],
-      "oban.pro.plugins.dynamic_lifeline.rescued_count": metadata[:rescued_count]
+      "oban.pro.plugins.dynamic_lifeline.discarded_count":
+        length(metadata[:discarded_jobs] || []),
+      "oban.pro.plugins.dynamic_lifeline.rescued_count": length(metadata[:rescued_jobs] || [])
     }
   end
 

--- a/instrumentation/opentelemetry_oban/test/opentelemetry_oban/plugin_handler_test.exs
+++ b/instrumentation/opentelemetry_oban/test/opentelemetry_oban/plugin_handler_test.exs
@@ -45,7 +45,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       %{plugin: Elixir.Oban.Plugins.Stager}
     )
 
-    refute_receive {:span, span(name: "Elixir.Oban.Plugins.Stager process")}
+    refute_receive {:span, span(name: "Oban.Plugins.Stager process")}
   end
 
   test "records span on plugin execution" do
@@ -61,7 +61,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       %{plugin: Elixir.Oban.Plugins.Stager}
     )
 
-    assert_receive {:span, span(name: "Elixir.Oban.Plugins.Stager process")}
+    assert_receive {:span, span(name: "Oban.Plugins.Stager process")}
   end
 
   test "records span on plugin error" do
@@ -97,7 +97,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
 
     assert_receive {:span,
                     span(
-                      name: "Elixir.Oban.Plugins.Stager process",
+                      name: "Oban.Plugins.Stager process",
                       attributes: span_attributes,
                       events: events,
                       status: ^expected_status
@@ -113,8 +113,11 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       )
     ] = :otel_events.list(events)
 
-    assert [:"exception.stacktrace", :"exception.type"] ==
-             Enum.sort(Map.keys(:otel_attributes.map(event_attributes)))
+    assert %{
+             "exception.type": "Elixir.UndefinedFunctionError",
+             "exception.message":
+               "function Some.error/0 is undefined (module Some is not available)"
+           } = :otel_attributes.map(event_attributes)
   end
 
   test "records span on plugin error with non-exception reason" do
@@ -124,7 +127,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       %{plugin: Elixir.Oban.Plugins.Stager}
     )
 
-    # Test with an atom error reason like :badarg
+    # `:badarg` normalises to %ArgumentError{}, so it records a message like any other exception
     stacktrace = [{Some, :error, [], []}]
 
     :telemetry.execute(
@@ -143,13 +146,13 @@ defmodule OpentelemetryOban.PluginHandlerTest do
 
     assert_receive {:span,
                     span(
-                      name: "Elixir.Oban.Plugins.Stager process",
+                      name: "Oban.Plugins.Stager process",
                       attributes: span_attributes,
                       events: events,
                       status: ^expected_status
                     )}
 
-    refute Map.has_key?(:otel_attributes.map(span_attributes), :"error.type")
+    assert %{"error.type": "ArgumentError"} = :otel_attributes.map(span_attributes)
 
     [
       event(
@@ -158,8 +161,99 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       )
     ] = :otel_events.list(events)
 
+    assert %{
+             "exception.type": "Elixir.ArgumentError",
+             "exception.message": "argument error"
+           } = :otel_attributes.map(event_attributes)
+  end
+
+  test "records span on plugin error with a reason that cannot be normalised" do
+    :telemetry.execute(
+      [:oban, :plugin, :start],
+      %{system_time: System.system_time()},
+      %{plugin: Elixir.Oban.Plugins.Stager}
+    )
+
+    stacktrace = [{Some, :error, [], []}]
+
+    :telemetry.execute(
+      [:oban, :plugin, :exception],
+      %{duration: 444},
+      %{
+        plugin: Elixir.Oban.Plugins.Stager,
+        kind: :throw,
+        stacktrace: stacktrace,
+        reason: {:some, :value}
+      }
+    )
+
+    expected_status =
+      OpenTelemetry.status(:error, Exception.format_banner(:throw, {:some, :value}, stacktrace))
+
+    assert_receive {:span,
+                    span(
+                      name: "Oban.Plugins.Stager process",
+                      attributes: span_attributes,
+                      events: events,
+                      status: ^expected_status
+                    )}
+
+    refute Map.has_key?(:otel_attributes.map(span_attributes), :"error.type")
+
+    [event(name: :exception, attributes: event_attributes)] = :otel_events.list(events)
+
+    # The Erlang API accepts any term but records no message
     assert [:"exception.stacktrace", :"exception.type"] ==
              Enum.sort(Map.keys(:otel_attributes.map(event_attributes)))
+  end
+
+  # Plugins report failure through the `{:error, meta}` return value of `:telemetry.span/3`, which
+  # emits a `:stop` event rather than an `:exception` event.
+  test "marks the span as errored when a stop event carries a wrapped :error" do
+    # Oban.Plugins.{Cron,Lifeline,Pruner,Reindexer} put their whole return value under :error
+    execute_plugin(Oban.Plugins.Cron, %{error: {:error, %RuntimeError{message: "insert failed"}}})
+
+    expected_status = OpenTelemetry.status(:error, "insert failed")
+
+    assert_receive {:span,
+                    span(
+                      name: "Oban.Plugins.Cron process",
+                      attributes: span_attributes,
+                      status: ^expected_status
+                    )}
+
+    assert %{"error.type": "RuntimeError"} = :otel_attributes.map(span_attributes)
+  end
+
+  test "marks the span as errored when a stop event carries a bare :error" do
+    # Oban.Stager destructures {:error, reason} and puts the bare reason under :error
+    execute_plugin(Oban.Stager, %{error: %RuntimeError{message: "notify failed"}})
+
+    expected_status = OpenTelemetry.status(:error, "notify failed")
+
+    assert_receive {:span,
+                    span(
+                      name: "Oban.Stager process",
+                      attributes: span_attributes,
+                      status: ^expected_status
+                    )}
+
+    assert %{"error.type": "RuntimeError"} = :otel_attributes.map(span_attributes)
+  end
+
+  test "leaves the span unset when a stop event carries a nil :error" do
+    # Oban.Plugins.Reindexer has no else branch for the non-leader case, so every follower node
+    # reports a nil :error on each scheduled run. That is a no-op, not a failure.
+    execute_plugin(Oban.Plugins.Reindexer, %{error: nil})
+
+    assert_receive {:span,
+                    span(
+                      name: "Oban.Plugins.Reindexer process",
+                      attributes: span_attributes,
+                      status: :undefined
+                    )}
+
+    refute Map.has_key?(:otel_attributes.map(span_attributes), :"error.type")
   end
 
   describe "[:oban, :plugin, :stop] spans" do
@@ -167,7 +261,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       execute_plugin(Oban.Plugins.Cron, %{jobs: [1, 3, 4]})
 
       assert %{
-               "oban.plugin": Elixir.Oban.Plugins.Cron,
+               "oban.plugin": "Oban.Plugins.Cron",
                "oban.plugins.cron.jobs_count": 3
              } ==
                receive_span_attrs(Oban.Plugins.Cron)
@@ -178,10 +272,13 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       # scheduled insert fails (Oban.Plugins.Cron returns {:error, meta} with an
       # :error key and no :jobs). jobs_count must default to 0 rather than crash
       # the telemetry handler on length(nil), which would detach it.
-      execute_plugin(Oban.Plugins.Cron, %{error: %RuntimeError{message: "insert failed"}})
+      execute_plugin(Oban.Plugins.Cron, %{
+        error: {:error, %RuntimeError{message: "insert failed"}}
+      })
 
       assert %{
-               "oban.plugin": Elixir.Oban.Plugins.Cron,
+               "error.type": "RuntimeError",
+               "oban.plugin": "Oban.Plugins.Cron",
                "oban.plugins.cron.jobs_count": 0
              } ==
                receive_span_attrs(Oban.Plugins.Cron)
@@ -191,17 +288,20 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       execute_plugin(Oban.Plugins.Gossip, %{gossip_count: 3})
 
       assert %{
-               "oban.plugin": Elixir.Oban.Plugins.Gossip,
+               "oban.plugin": "Oban.Plugins.Gossip",
                "oban.plugins.gossip.gossip_count": 3
              } ==
                receive_span_attrs(Oban.Plugins.Gossip)
     end
 
     test "Oban.Plugins.Lifeline plugin" do
-      execute_plugin(Oban.Plugins.Lifeline, %{discarded_count: 3, rescued_count: 2})
+      execute_plugin(Oban.Plugins.Lifeline, %{
+        discarded_jobs: [1, 2, 3],
+        rescued_jobs: [4, 5]
+      })
 
       assert %{
-               "oban.plugin": Elixir.Oban.Plugins.Lifeline,
+               "oban.plugin": "Oban.Plugins.Lifeline",
                "oban.plugins.lifeline.discarded_count": 3,
                "oban.plugins.lifeline.rescued_count": 2
              } ==
@@ -212,7 +312,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       execute_plugin(Oban.Plugins.Pruner, %{pruned_count: 3})
 
       assert %{
-               "oban.plugin": Elixir.Oban.Plugins.Pruner,
+               "oban.plugin": "Oban.Plugins.Pruner",
                "oban.plugins.pruner.pruned_count": 3
              } ==
                receive_span_attrs(Oban.Plugins.Pruner)
@@ -222,7 +322,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       execute_plugin(Oban.Pro.Plugins.DynamicCron, %{jobs: [1, 3, 4]})
 
       assert %{
-               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicCron,
+               "oban.plugin": "Oban.Pro.Plugins.DynamicCron",
                "oban.pro.plugins.dynamic_cron.jobs_count": 3
              } ==
                receive_span_attrs(Oban.Pro.Plugins.DynamicCron)
@@ -230,21 +330,25 @@ defmodule OpentelemetryOban.PluginHandlerTest do
 
     test "Oban.Pro.Plugins.DynamicCron plugin without :jobs in metadata" do
       execute_plugin(Oban.Pro.Plugins.DynamicCron, %{
-        error: %RuntimeError{message: "insert failed"}
+        error: {:error, %RuntimeError{message: "insert failed"}}
       })
 
       assert %{
-               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicCron,
+               "error.type": "RuntimeError",
+               "oban.plugin": "Oban.Pro.Plugins.DynamicCron",
                "oban.pro.plugins.dynamic_cron.jobs_count": 0
              } ==
                receive_span_attrs(Oban.Pro.Plugins.DynamicCron)
     end
 
     test "Oban.Pro.Plugins.DynamicLifeline plugin" do
-      execute_plugin(Oban.Pro.Plugins.DynamicLifeline, %{discarded_count: 3, rescued_count: 2})
+      execute_plugin(Oban.Pro.Plugins.DynamicLifeline, %{
+        discarded_jobs: [1, 2, 3],
+        rescued_jobs: [4, 5]
+      })
 
       assert %{
-               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicLifeline,
+               "oban.plugin": "Oban.Pro.Plugins.DynamicLifeline",
                "oban.pro.plugins.dynamic_lifeline.discarded_count": 3,
                "oban.pro.plugins.dynamic_lifeline.rescued_count": 2
              } ==
@@ -255,7 +359,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       execute_plugin(Oban.Pro.Plugins.DynamicPrioritizer, %{reprioritized_count: 3})
 
       assert %{
-               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicPrioritizer,
+               "oban.plugin": "Oban.Pro.Plugins.DynamicPrioritizer",
                "oban.pro.plugins.dynamic_prioritizer.reprioritized_count": 3
              } ==
                receive_span_attrs(Oban.Pro.Plugins.DynamicPrioritizer)
@@ -265,7 +369,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       execute_plugin(Oban.Pro.Plugins.DynamicPruner, %{pruned_count: 3})
 
       assert %{
-               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicPruner,
+               "oban.plugin": "Oban.Pro.Plugins.DynamicPruner",
                "oban.pro.plugins.dynamic_pruner.pruned_count": 3
              } ==
                receive_span_attrs(Oban.Pro.Plugins.DynamicPruner)
@@ -277,7 +381,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
       })
 
       assert %{
-               "oban.plugin": Elixir.Oban.Pro.Plugins.DynamicScaler,
+               "oban.plugin": "Oban.Pro.Plugins.DynamicScaler",
                "oban.pro.plugins.dynamic_scaler.scaler.last_scaled_to": 3,
                "oban.pro.plugins.dynamic_scaler.scaler.last_scaled_at": "2021-08-01T12:00:00Z"
              } ==
@@ -286,7 +390,7 @@ defmodule OpentelemetryOban.PluginHandlerTest do
   end
 
   defp receive_span_attrs(name) do
-    name = "#{name} process"
+    name = "#{inspect(name)} process"
 
     assert_receive(
       {:span, span(name: ^name, attributes: attributes)},

--- a/instrumentation/opentelemetry_oban/test/opentelemetry_oban/plugin_integration_test.exs
+++ b/instrumentation/opentelemetry_oban/test/opentelemetry_oban/plugin_integration_test.exs
@@ -1,0 +1,169 @@
+defmodule OpentelemetryOban.PluginIntegrationTest do
+  @moduledoc """
+  Exercises real Oban plugins so the attributes and statuses are asserted against the metadata
+  Oban actually emits, rather than against hand-written `:telemetry.execute/3` payloads.
+  """
+
+  use DataCase
+
+  require Record
+
+  alias Oban.Job
+
+  for {name, spec} <- Record.extract_all(from_lib: "opentelemetry/include/otel_span.hrl") do
+    Record.defrecord(name, spec)
+  end
+
+  for {name, spec} <- Record.extract_all(from_lib: "opentelemetry_api/include/opentelemetry.hrl") do
+    Record.defrecord(name, spec)
+  end
+
+  defmodule RaisingPlugin do
+    @moduledoc false
+
+    @behaviour Oban.Plugin
+
+    use GenServer
+
+    @impl Oban.Plugin
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:name])
+
+    @impl Oban.Plugin
+    def validate(_opts), do: :ok
+
+    @impl GenServer
+    def init(opts), do: {:ok, %{conf: opts[:conf]}}
+
+    @impl GenServer
+    def handle_info(:run, state) do
+      meta = %{conf: state.conf, plugin: __MODULE__}
+
+      :telemetry.span([:oban, :plugin], meta, fn ->
+        raise ArgumentError, "boom from plugin"
+      end)
+
+      {:noreply, state}
+    end
+  end
+
+  setup do
+    :application.stop(:opentelemetry)
+    :application.set_env(:opentelemetry, :tracer, :otel_tracer_default)
+
+    :application.set_env(:opentelemetry, :processors, [
+      {:otel_batch_processor, %{scheduled_delay_ms: 1, exporter: {:otel_exporter_pid, self()}}}
+    ])
+
+    :application.start(:opentelemetry)
+
+    TestHelpers.remove_oban_handlers()
+    OpentelemetryOban.setup()
+
+    :ok
+  end
+
+  test "Oban.Plugins.Lifeline reports the jobs it actually rescued and discarded" do
+    orphaned_at = DateTime.add(DateTime.utc_now(), -2, :hour)
+
+    insert_orphan(attempt: 1, max_attempts: 20, attempted_at: orphaned_at)
+    insert_orphan(attempt: 20, max_attempts: 20, attempted_at: orphaned_at)
+
+    run_plugin({Oban.Plugins.Lifeline, interval: :timer.hours(1), rescue_after: 1}, :rescue)
+
+    assert %{
+             "oban.plugin": "Oban.Plugins.Lifeline",
+             "oban.plugins.lifeline.rescued_count": 1,
+             "oban.plugins.lifeline.discarded_count": 1
+           } = receive_span_attrs(Oban.Plugins.Lifeline)
+  end
+
+  test "a failing plugin produces an errored span" do
+    # REINDEX CONCURRENTLY cannot run inside the sandbox transaction, so the plugin fails for real
+    # and reports it through the {:error, meta} return value of :telemetry.span/3.
+    run_plugin({Oban.Plugins.Reindexer, schedule: "@daily"}, :reindex)
+
+    assert_receive {:span,
+                    span(
+                      name: "Oban.Plugins.Reindexer process",
+                      status: status(code: :error)
+                    )},
+                   1000
+  end
+
+  test "a non-leader plugin run is not reported as an error" do
+    run_plugin({Oban.Plugins.Reindexer, schedule: "@daily"}, :reindex,
+      peer: {Oban.Peers.Isolated, leader?: false}
+    )
+
+    assert_receive {:span,
+                    span(
+                      name: "Oban.Plugins.Reindexer process",
+                      attributes: attributes,
+                      status: :undefined
+                    )},
+                   1000
+
+    refute Map.has_key?(:otel_attributes.map(attributes), :"error.type")
+  end
+
+  test "a raising plugin records the exception message" do
+    run_plugin(RaisingPlugin, :run)
+
+    expected_name = "#{inspect(RaisingPlugin)} process"
+
+    assert_receive {:span,
+                    span(
+                      name: ^expected_name,
+                      attributes: attributes,
+                      events: events
+                    )},
+                   1000
+
+    assert %{"error.type": "ArgumentError"} = :otel_attributes.map(attributes)
+
+    [event(name: :exception, attributes: event_attributes)] = :otel_events.list(events)
+
+    assert %{
+             "exception.type": "Elixir.ArgumentError",
+             "exception.message": "boom from plugin"
+           } = :otel_attributes.map(event_attributes)
+  end
+
+  defp insert_orphan(fields) do
+    TestRepo.insert!(
+      struct(%Job{args: %{}, queue: "events", state: "executing", worker: "TestJob"}, fields)
+    )
+  end
+
+  defp run_plugin(plugin, message, opts \\ []) do
+    peer = Keyword.get(opts, :peer, Oban.Peers.Isolated)
+    plugin_module = if is_tuple(plugin), do: elem(plugin, 0), else: plugin
+
+    start_supervised!(
+      {Oban,
+       name: __MODULE__.Oban,
+       repo: TestRepo,
+       notifier: Oban.Notifiers.PG,
+       peer: peer,
+       queues: [],
+       stage_interval: :infinity,
+       plugins: [plugin]}
+    )
+
+    __MODULE__.Oban
+    |> Oban.Registry.whereis({:plugin, plugin_module})
+    |> send(message)
+  end
+
+  defp receive_span_attrs(plugin) do
+    name = "#{inspect(plugin)} process"
+
+    assert_receive(
+      {:span, span(name: ^name, attributes: attributes)},
+      1000,
+      "expected span with name #{name} to be received"
+    )
+
+    :otel_attributes.map(attributes)
+  end
+end


### PR DESCRIPTION
Supersedes #195. That PR's implementation did not survive review, so this is a fresh branch off `main` rather than a rebase, but the original report and problem framing came from @andrewhr and the credit for finding this belongs to them.

- Oban plugins signal failure through the `{:error, meta}` return value of `:telemetry.span/3`, which emits a `:stop` event and not an `:exception` event. Every failing plugin run therefore arrived at the backend with an unset status, indistinguishable from a successful one, so plugin failures were invisible in exactly the situation where a trace is most useful.
- The one exception to the above is deliberate: a `nil` error is how `Oban.Plugins.Reindexer` reports the non-leader case, which happens on every follower node on every scheduled run. Treating that as a failure would have produced continuous false alarms.
- Plugin exception spans recorded no `exception.message`, which is the field a human actually reads first when triaging.
- The Lifeline and DynamicLifeline count attributes read metadata keys Oban does not emit, so they were never populated. Because the exporter serializes them anyway, they reached the backend as the literal string `"nil"`, which is worse than absent: it poisons any aggregation over those attributes.
- Job exception spans matched on a metadata key that Oban's documented job telemetry does not include, so the intended data was not being read at all.
- The plugin identity was emitted with the internal `Elixir.` prefix, which does not match the module name users write in their own Oban config, making spans hard to correlate with the code that produced them. This is a breaking change for anyone filtering on the attribute or grouping on the span name, and it is called out in the CHANGELOG.