### PR TITLE
fix(opentelemetry_finch): conform error span status to semconv

### DIFF
--- a/instrumentation/opentelemetry_finch/CHANGELOG.md
+++ b/instrumentation/opentelemetry_finch/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Replace deprecated `OpenTelemetry.SemanticConventions.Trace` attributes with `opentelemetry_semantic_conventions` >= v1.27.0 modules (`HTTPAttributes`, `ServerAttributes`, `URLAttributes`)
 
+### Fixed
+
+* Leave the span status description unset for 4xx and 5xx responses, since the reason is inferable from `http.response.status_code`
+
 ## 0.3.0
 
 ### Changed

--- a/instrumentation/opentelemetry_finch/lib/opentelemetry_finch.ex
+++ b/instrumentation/opentelemetry_finch/lib/opentelemetry_finch.ex
@@ -338,8 +338,11 @@ defmodule OpentelemetryFinch do
 
   defp maybe_add_error_type(attrs, _status, _result), do: attrs
 
+  # SemConv: "Don't set the span status description if the reason can be inferred
+  # from `http.response.status_code`."
+  # https://github.com/open-telemetry/semantic-conventions/blob/v1.39.0/docs/http/http-spans.md#L107
   defp set_span_status(span, _result, status) when is_integer(status) and status >= 400 do
-    OpenTelemetry.Span.set_status(span, OpenTelemetry.status(:error, to_string(status)))
+    OpenTelemetry.Span.set_status(span, OpenTelemetry.status(:error, ""))
   end
 
   defp set_span_status(span, {:error, reason}, _status) do

--- a/instrumentation/opentelemetry_finch/test/opentelemetry_finch_test.exs
+++ b/instrumentation/opentelemetry_finch/test/opentelemetry_finch_test.exs
@@ -315,7 +315,7 @@ defmodule OpentelemetryFinchTest do
                     span(
                       name: "GET",
                       kind: :client,
-                      status: {:status, :error, "404"},
+                      status: {:status, :error, ""},
                       attributes: attributes
                     )}
 
@@ -380,7 +380,7 @@ defmodule OpentelemetryFinchTest do
                     span(
                       name: "GET",
                       kind: :client,
-                      status: {:status, :error, "503"},
+                      status: {:status, :error, ""},
                       attributes: attributes
                     )}
 


### PR DESCRIPTION
- The span status description duplicated `http.response.status_code` and `error.type`, which semantic conventions advise against: [http-spans.md#L107](https://github.com/open-telemetry/semantic-conventions/blob/v1.39.0/docs/http/http-spans.md#L107) and [recording-errors.md#L55](https://github.com/open-telemetry/semantic-conventions/blob/v1.39.0/docs/general/recording-errors.md#L55).
- Nothing becomes unqueryable: both values stay on the span as attributes, so the description was pure duplication.
- An empty description is [equivalent to an absent one](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.53.0/specification/trace/api.md#L575) per the tracing API, so this is expressed without a separate code path.
- The same concern was raised in review on #258 and accepted by the author at the time, but the behavior returned with #470; the inline spec citation is there to keep it from regressing a third time.